### PR TITLE
Ignore `postId` param reader validation

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -152,6 +152,7 @@ export default class API extends EventEmitter {
       if (!postId.match(postIdParams.regex)) {
         return this.sendJSON(res, { error: `postId is invalid format` }, 400)
       }
+      /*
       let buffer: Buffer
       switch (postIdParams.type) {
         case 'BigInt':
@@ -167,6 +168,7 @@ export default class API extends EventEmitter {
         case 'String':
           break
       }
+      */
       req.params.postId = postId
       next()
     },


### PR DESCRIPTION
Works around an unhandled exception with the `postId` parameter endpoint receives a request containing letters.

Will be fully fixed in a future release, but for now this will prevent the backend API from crashing.