### PR TITLE
bugfix: profile upserts double increment ranking, votes

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -512,18 +512,6 @@ export default class Database {
               },
             }),
           )
-          // update profile rankings after post upsert
-          upserts.push(
-            this.db.profile.update({
-              where: {
-                platform_id: {
-                  platform,
-                  id: profileId,
-                },
-              },
-              data: increments,
-            }),
-          )
         }
       }
     }


### PR DESCRIPTION
It was observed that profile rankings would reflect 2 additional upvotes or downvotes after a single vote was cast on their post. This commit removes the additional profile upsert when adding an upsert for a post, since the profile ranking data is already being upserted beforehand.