### PR TITLE
Exclude `nanomsg` submodule, not all

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "exclude": [
-    "submodules",
+    "submodules/nanomsg",
     "node_modules"
   ],
   "compilerOptions": {


### PR DESCRIPTION
Need to update the `tsconfig.json` file to not exclude `rank-lib` from compilation.