### PR TITLE
bugfix: duplicate profile decrements on rewind

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -635,10 +635,6 @@ export default class Database {
                     },
                   },
                 },
-                // MUST decrement profile counters since post counts towards profile
-                profile: {
-                  update: decrements,
-                },
                 // decrement post counters
                 ...decrements,
               },


### PR DESCRIPTION
This commit removes the additional profile rewind that is executed when `Post` data is rewound.