### PR TITLE
Add timespan parameter to `/stats` API queries

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,7 +57,7 @@ export default class API extends EventEmitter {
     this.router.param('statsRoute', this.param.statsRoute)
     // Router endpoint configuration (DEEPEST ROUTES FIRST!)
     this.router.get(
-      '/stats/:platform/:statsRoute(profiles/[a-z-]+|posts/[a-z-]+)/:timespan?',
+      '/stats/:platform/:statsRoute(profiles/[a-z-]+|posts/[a-z-]+)/:timespan?/:votes?',
       this.get.stats,
     )
     this.router.get(
@@ -322,8 +322,9 @@ export default class API extends EventEmitter {
         const platform = req.params.platform as ScriptChunkPlatformUTF8
         const statsRoute = req.params.statsRoute as StatsRoute
         const timespan = req.params.timespan as Timespan
+        const votes = Boolean(req.params.votes == 'includeVotes')
         const dbMethod: keyof typeof this.db = StatsRoutes[statsRoute]
-        const result = await this.db[dbMethod](platform, timespan)
+        const result = await this.db[dbMethod](platform, timespan, votes)
         const t1 = (performance.now() - t0).toFixed(3)
         log([
           ['api', 'get.stats'],

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,6 +17,7 @@ type Parameter =
   | 'postId'
   | 'scriptPayload'
   | 'statsRoute'
+  | 'pageNum'
 type ParameterHandler = (
   req: Request,
   res: Response,

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -204,6 +204,7 @@ export default class Database {
   async getStatsPlatformProfilesTopRanked(
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
+    includeVotes: boolean,
   ) {
     try {
       const result = await this.db.profile.findMany({
@@ -228,11 +229,13 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
-          ranks: {
-            select: {
-              txid: true,
-            },
-          },
+          ranks: !includeVotes
+            ? undefined
+            : {
+                select: {
+                  txid: true,
+                },
+              },
         },
       })
       return result.map(profile => {
@@ -242,7 +245,7 @@ export default class Database {
           ranking: String(profile.ranking),
           votesPositive: profile.votesPositive,
           votesNegative: profile.votesNegative,
-          votes: profile.ranks.map(rank => rank.txid),
+          votesTimespan: profile.ranks?.map(rank => rank.txid) ?? [],
         }
       })
     } catch (e) {
@@ -257,6 +260,7 @@ export default class Database {
   async getStatsPlatformProfilesLowestRanked(
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
+    includeVotes: boolean,
   ) {
     try {
       const result = await this.db.profile.findMany({
@@ -279,11 +283,13 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
-          ranks: {
-            select: {
-              txid: true,
-            },
-          },
+          ranks: !includeVotes
+            ? undefined
+            : {
+                select: {
+                  txid: true,
+                },
+              },
         },
       })
       return result.map(profile => {
@@ -293,7 +299,7 @@ export default class Database {
           ranking: String(profile.ranking),
           votesPositive: profile.votesPositive,
           votesNegative: profile.votesNegative,
-          votes: profile.ranks.map(rank => rank.txid),
+          votesTimespan: profile.ranks?.map(rank => rank.txid) ?? [],
         }
       })
     } catch (e) {
@@ -308,6 +314,7 @@ export default class Database {
   async getStatsPlatformPostsTopRanked(
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
+    includeVotes: boolean,
   ) {
     try {
       const result = await this.db.post.findMany({
@@ -333,11 +340,13 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
-          ranks: {
-            select: {
-              txid: true,
-            },
-          },
+          ranks: !includeVotes
+            ? undefined
+            : {
+                select: {
+                  txid: true,
+                },
+              },
         },
       })
       return result.map(post => {
@@ -348,7 +357,7 @@ export default class Database {
           ranking: String(post.ranking),
           votesPositive: post.votesPositive,
           votesNegative: post.votesNegative,
-          votes: post.ranks.map(rank => rank.txid),
+          votesTimespan: post.ranks?.map(rank => rank.txid) ?? [],
         }
       })
     } catch (e) {
@@ -363,6 +372,7 @@ export default class Database {
   async getStatsPlatformPostsLowestRanked(
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
+    includeVotes: boolean,
   ) {
     try {
       const result = await this.db.post.findMany({
@@ -388,11 +398,13 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
-          ranks: {
-            select: {
-              txid: true,
-            },
-          },
+          ranks: !includeVotes
+            ? undefined
+            : {
+                select: {
+                  txid: true,
+                },
+              },
         },
       })
       return result.map(post => {
@@ -403,7 +415,7 @@ export default class Database {
           ranking: String(post.ranking),
           votesPositive: post.votesPositive,
           votesNegative: post.votesNegative,
-          votes: post.ranks.map(rank => rank.txid),
+          votesTimespan: post.ranks?.map(rank => rank.txid) ?? [],
         }
       })
     } catch (e) {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -228,6 +228,11 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
+          ranks: {
+            select: {
+              txid: true,
+            },
+          },
         },
       })
       return result.map(profile => {
@@ -237,6 +242,7 @@ export default class Database {
           ranking: String(profile.ranking),
           votesPositive: profile.votesPositive,
           votesNegative: profile.votesNegative,
+          votes: profile.ranks.map(rank => rank.txid),
         }
       })
     } catch (e) {
@@ -273,6 +279,11 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
+          ranks: {
+            select: {
+              txid: true,
+            },
+          },
         },
       })
       return result.map(profile => {
@@ -282,6 +293,7 @@ export default class Database {
           ranking: String(profile.ranking),
           votesPositive: profile.votesPositive,
           votesNegative: profile.votesNegative,
+          votes: profile.ranks.map(rank => rank.txid),
         }
       })
     } catch (e) {
@@ -321,6 +333,11 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
+          ranks: {
+            select: {
+              txid: true,
+            },
+          },
         },
       })
       return result.map(post => {
@@ -331,6 +348,7 @@ export default class Database {
           ranking: String(post.ranking),
           votesPositive: post.votesPositive,
           votesNegative: post.votesNegative,
+          votes: post.ranks.map(rank => rank.txid),
         }
       })
     } catch (e) {
@@ -370,6 +388,11 @@ export default class Database {
           ranking: true,
           votesPositive: true,
           votesNegative: true,
+          ranks: {
+            select: {
+              txid: true,
+            },
+          },
         },
       })
       return result.map(post => {
@@ -380,6 +403,7 @@ export default class Database {
           ranking: String(post.ranking),
           votesPositive: post.votesPositive,
           votesNegative: post.votesNegative,
+          votes: post.ranks.map(rank => rank.txid),
         }
       })
     } catch (e) {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -205,6 +205,7 @@ export default class Database {
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'day',
     includeVotes: boolean,
+    pageNum: number = 0,
   ) {
     try {
       const result = await this.db.profile.findMany({
@@ -235,6 +236,11 @@ export default class Database {
                 select: {
                   txid: true,
                 },
+                orderBy: {
+                  timestamp: 'desc',
+                },
+                skip: pageNum ? 10 * pageNum : undefined,
+                take: 10,
               },
         },
       })
@@ -261,6 +267,7 @@ export default class Database {
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
     includeVotes: boolean,
+    pageNum: number = 0,
   ) {
     try {
       const result = await this.db.profile.findMany({
@@ -289,6 +296,11 @@ export default class Database {
                 select: {
                   txid: true,
                 },
+                orderBy: {
+                  timestamp: 'desc',
+                },
+                skip: pageNum ? 10 * pageNum : undefined,
+                take: 10,
               },
         },
       })
@@ -315,6 +327,7 @@ export default class Database {
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
     includeVotes: boolean,
+    pageNum: number = 0,
   ) {
     try {
       const result = await this.db.post.findMany({
@@ -346,6 +359,11 @@ export default class Database {
                 select: {
                   txid: true,
                 },
+                orderBy: {
+                  timestamp: 'desc',
+                },
+                skip: pageNum ? 10 * pageNum : undefined,
+                take: 10,
               },
         },
       })
@@ -373,6 +391,7 @@ export default class Database {
     platform: ScriptChunkPlatformUTF8,
     timespan: Timespan = 'all',
     includeVotes: boolean,
+    pageNum: number = 0,
   ) {
     try {
       const result = await this.db.post.findMany({
@@ -404,6 +423,11 @@ export default class Database {
                 select: {
                   txid: true,
                 },
+                orderBy: {
+                  timestamp: 'desc',
+                },
+                skip: pageNum ? 10 * pageNum : undefined,
+                take: 10,
               },
         },
       })

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -203,7 +203,7 @@ export default class Database {
    */
   async getStatsPlatformProfilesTopRanked(
     platform: ScriptChunkPlatformUTF8,
-    timespan: Timespan = 'all',
+    timespan: Timespan = 'day',
     includeVotes: boolean,
   ) {
     try {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -265,7 +265,7 @@ export default class Database {
    */
   async getStatsPlatformProfilesLowestRanked(
     platform: ScriptChunkPlatformUTF8,
-    timespan: Timespan = 'all',
+    timespan: Timespan = 'day',
     includeVotes: boolean,
     pageNum: number = 0,
   ) {
@@ -325,7 +325,7 @@ export default class Database {
    */
   async getStatsPlatformPostsTopRanked(
     platform: ScriptChunkPlatformUTF8,
-    timespan: Timespan = 'all',
+    timespan: Timespan = 'day',
     includeVotes: boolean,
     pageNum: number = 0,
   ) {
@@ -389,7 +389,7 @@ export default class Database {
    */
   async getStatsPlatformPostsLowestRanked(
     platform: ScriptChunkPlatformUTF8,
-    timespan: Timespan = 'all',
+    timespan: Timespan = 'day',
     includeVotes: boolean,
     pageNum: number = 0,
   ) {


### PR DESCRIPTION
This commit adds the requisite conditional to database queries for fetching top- and lowest-ranked profiles/posts over the specified timespan. The API was also appropriately adjusted to accommodate the new `timespan` GET parameter.