### PR TITLE
Revert some config

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,11 +2,7 @@ import { Express, Router, Request, Response, NextFunction } from 'express'
 import express from 'express'
 import Database from './database'
 import { API_SERVER_PORT } from '../util/constants'
-import {
-  PLATFORMS,
-  log,
-  type ScriptChunkPlatformUTF8,
-} from '../submodules/rank-lib'
+import { PLATFORMS, log, type ScriptChunkPlatformUTF8 } from 'rank-lib'
 import { Server } from 'http'
 import { EventEmitter } from 'events'
 

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -8,7 +8,7 @@ import type {
   ProfileMap,
   ScriptChunkPlatformUTF8,
   ScriptChunkSentimentUTF8,
-} from '../submodules/rank-lib'
+} from 'rank-lib'
 
 type RankStatistics = {
   ranking: bigint

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from './prisma/client'
+import { PrismaClient } from '@prisma/client'
 import { randomUUID } from 'crypto'
 import { API_STATS_RESULT_COUNT, ERR } from '../util/constants'
 import type {

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -13,7 +13,7 @@ import {
   toPlatformUTF8,
   toSentimentUTF8,
   log,
-} from '../submodules/rank-lib'
+} from 'rank-lib'
 import {
   ERR,
   NNG_PUB_DEFAULT_SOCKET_PATH,
@@ -29,7 +29,7 @@ import {
   RANK_BLOCK_GENESIS_V1,
   RANK_OUTPUT_MIN_VALID_SATS,
   RANK_SCRIPT_CHUNKS,
-} from '../submodules/rank-lib'
+} from 'rank-lib'
 import type {
   LogEntry,
   RankOutput,
@@ -41,7 +41,7 @@ import type {
   ScriptChunkField,
   ScriptChunkPlatformUTF8,
   ScriptChunkSentimentUTF8,
-} from '../submodules/rank-lib'
+} from 'rank-lib'
 /** NNG types */
 type NNGMessageType =
   | 'mempooltxadd'

--- a/schema.prisma
+++ b/schema.prisma
@@ -6,7 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
-  output = "./lib/prisma/client"
+  output = "./node_modules/.prisma"
 }
 
 datasource db {

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -1,6 +1,6 @@
 import Indexer from '../lib/indexer'
 import API from '../lib/api'
-import { log } from '../submodules/rank-lib'
+import { log } from 'rank-lib'
 import {
   ERR,
   NNG_PUB_DEFAULT_SOCKET_PATH,


### PR DESCRIPTION
This branch reverts the previous changes to the `rank-lib` imports and also configures the Prisma client to output its generated library to the local `node_modules/.prisma` directory. This allows the `database` module to import using the `package.json` path and keeping the generated Prisma library local to `rank-backend-ts`.