### PR TITLE
Another change to Prisma output path

### DIFF
--- a/schema.prisma
+++ b/schema.prisma
@@ -6,7 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
-  output = "./node_modules/@prisma"
+  output = "./node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
```
Error:
Generating client into /app/node_modules/@prisma/client is not allowed.
This package is used by `prisma generate` and overwriting its content is dangerous.

Suggestion:
In /app/schema.prisma replace:

9 output   = "./node_modules/@prisma/client"
with
9 output   = "./node_modules/.prisma/client"

You won't need to change your imports.
Imports from `@prisma/client` will be automatically forwarded to `.prisma/client
```