### PR TITLE
Pass `DATABASE_URL` env string to `Database` constructor

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ type Exception = [number | string, string]
  * SETUP
  */
 // Modules
-const db = new Database()
+const db = new Database(process.env.DATABASE_URL)
 const indexer = new Indexer(
   db,
   String(process.argv[2] || NNG_PUB_DEFAULT_SOCKET_PATH), // /path/to/pub.pipe

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -49,10 +49,10 @@ const getTimestampUTC = (timespan: Timespan): number => {
 export default class Database {
   private db: PrismaClient
 
-  constructor() {
+  constructor(datasourceUrl: string) {
     this.db = new PrismaClient({
       errorFormat: 'minimal',
-      datasourceUrl: process.env.DATABASE_URL,
+      datasourceUrl,
     })
   }
 


### PR DESCRIPTION
This commit changes the instantiation behavior to load the `DATABASE_URL` directly into the `Database` object, rather than strictly loading it from `process.env`.