### PR TITLE
Adjust API and IPC database queries

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -354,18 +354,18 @@ export default class API extends EventEmitter {
           'profiles' | 'posts',
           'top' | 'lowest',
         ]
-        const timespan = req.params.timespan as Timespan
-        const votes = Boolean(req.params.votes == 'includeVotes')
+        const startTime = req.params.timespan as Timespan
+        const includeVotes = Boolean(req.params.votes == 'includeVotes')
         const pageNum = Number(req.params.pageNum)
         const dbMethod: keyof typeof this.db = StatsRoutes[statsRoute]
-        const result = await this.db[dbMethod](
+        const result = await this.db[dbMethod]({
           platform,
-          timespan,
-          dataType,
+          startTime: startTime,
+          dataType: dataType == 'profiles' ? 'profileId' : 'postId',
           rankingType,
-          votes,
+          includeVotes,
           pageNum,
-        )
+        })
         const t1 = (performance.now() - t0).toFixed(3)
         log([
           ['api', 'get.stats'],

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -74,11 +74,28 @@ export default class Database {
    * @param timespan
    * @param scriptPayload
    */
-  async ipcGetScriptPayloadActivity(timespan: Timespan, scriptPayload: string) {
+  async ipcGetScriptPayloadActivity({
+    scriptPayload,
+    startTime,
+    endTime,
+  }: {
+    scriptPayload: string
+    startTime?: Timespan
+    endTime?: Timespan
+  }) {
+    if (!startTime) {
+      startTime = 'day'
+    }
+    if (!endTime) {
+      endTime = 'today'
+    }
     return await this.db.$transaction(async tx => {
       const results = await tx.rankTransaction.findMany({
         where: {
-          timestamp: { gte: getTimestampUTC(timespan) },
+          timestamp: {
+            gte: getTimestampUTC(startTime),
+            lte: getTimestampUTC(endTime),
+          },
           scriptPayload,
         },
         orderBy: {
@@ -96,15 +113,28 @@ export default class Database {
    * @param timespan
    * @returns {Promise<ScriptPayloadActivity[]>} Array of `ScriptPayloadActivity`
    */
-  async ipcGetScriptPayloadActivitySummary(
-    timespan: Timespan,
-  ): Promise<ScriptPayloadActivity[]> {
+  async ipcGetScriptPayloadActivitySummary({
+    startTime,
+    endTime,
+  }: {
+    startTime?: Timespan
+    endTime?: Timespan
+  }): Promise<ScriptPayloadActivity[]> {
+    if (!startTime) {
+      startTime = 'day'
+    }
+    if (!endTime) {
+      endTime = 'today'
+    }
     return await this.db.$transaction(async tx => {
       try {
         const group = await tx.rankTransaction.groupBy({
           by: ['scriptPayload'],
           where: {
-            timestamp: { gte: getTimestampUTC(timespan) },
+            timestamp: {
+              gte: getTimestampUTC(startTime),
+              lte: getTimestampUTC(endTime),
+            },
           },
           _count: true,
           _sum: {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -15,7 +15,7 @@ type RankStatistics = Pick<
   RankTarget,
   'ranking' | 'votesPositive' | 'votesNegative'
 >
-type Timespan = 'day' | 'week' | 'month' | 'quarter' | 'all'
+type Timespan = 'today' | 'day' | 'week' | 'month' | 'quarter' | 'all'
 export type ScriptPayloadActivity = {
   scriptPayload: string
   voteCount: number
@@ -33,6 +33,8 @@ const getTimestampUTC = (timespan: Timespan): number => {
     Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 1_000,
   )
   switch (timespan) {
+    case 'today':
+      return today
     case 'day':
       return today - 86_400
     case 'week':


### PR DESCRIPTION
It was observed that a `Post` that is indexed without a valid `postId` (e.g. Twitter post with an ID that does not match their current spec) would cause the back-end database query to fail, subsequently failing the API query. Prisma error: `Invalid value for argument `id``

Also, take the opportunity to adjust `Timespan` queries to be deterministic by adding an `endTime` parameter to the method definitions. This parameter will be used to cap `Timespan` queries at the 00:00 UTC time of the current day, but can also be used to cap the queries at the current time (i.e. `Date.now()`).