### PR TITLE
Bugfix: restore `finally` block to API queries

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-unsafe-finally */
 import { PrismaClient } from '../prisma/prisma-client-js'
 import { randomUUID } from 'crypto'
 import { API_STATS_RESULT_COUNT, ERR } from '../util/constants'
@@ -202,9 +203,10 @@ export default class Database {
         data.votesNegative = profile.votesNegative
       } catch (e) {
         // nothing to do here
+      } finally {
+        // always return data, even if default profile data
+        return data
       }
-      // always return data, even if default profile data
-      return data
     })
   }
   /**
@@ -308,9 +310,10 @@ export default class Database {
           votesPositive: profile.votesPositive,
           votesNegative: profile.votesNegative,
         }
+      } finally {
+        // always return data, even if default profile data
+        return data
       }
-      // always return data, even if default profile data
-      return data
     })
   }
   /**


### PR DESCRIPTION
Previously these were removed due to satisfy eslint rule `no-unsafe-finally`, which prevents a `return` (among other terminating statement) in the `finally` block. However, this introduced undesired behavior, whereby the `prisma.Profile.findUniqueOrThrow()` query would not return data, resulting in HTTP 404 errors on the front-end (as the API module was not receiving data to respond to the client request).

This commit reinstates the `finally` blocks in these queries and disables the eslint rule in the entire file.