### PR TITLE
Adjust extension registration implementation

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -182,6 +182,7 @@ export default class Database {
     id: string
     scriptPayload: string
     createdAt: Date
+    lastSeen: Date
   }) {
     try {
       await this.db.extensionInstance.create({ data })

--- a/package-lock.json
+++ b/package-lock.json
@@ -19223,10 +19223,10 @@
     },
     "submodules/bitcore-lib-xpi": {
       "name": "@abcpros/bitcore-lib-xpi",
-      "version": "8.25.31",
+      "version": "8.25.43",
       "license": "MIT",
       "dependencies": {
-        "@abcpros/bitcore-lib": "^8.25.31",
+        "@abcpros/bitcore-lib": "^8.25.43",
         "bn.js": "=4.11.8",
         "bs58": "^4.0.1",
         "buffer-compare": "=1.1.1",

--- a/schema.prisma
+++ b/schema.prisma
@@ -108,9 +108,12 @@ model ExtensionInstance {
   id            String            @unique
   scriptPayload String            @unique
   createdAt     DateTime
+  lastSeen      DateTime
+  optin         Boolean           @default(false)
   votesPositive Int               @default(0)
   votesNegative Int               @default(0)
   ranks         RankTransaction[]
 
   @@id([id, scriptPayload])
+  @@index([id(type: hash), scriptPayload(type: hash), optin(type: hash)])
 }

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -1,5 +1,8 @@
 import os from 'node:os'
-
+/**
+ * Extension configuration
+ */
+export const EXT_INSTANCE_ID_DIFFICULTY = 4
 /**
  * API configuration
  */

--- a/util/functions.ts
+++ b/util/functions.ts
@@ -1,0 +1,21 @@
+import { EXT_INSTANCE_ID_DIFFICULTY } from './constants'
+
+export async function isValidInstanceId({
+  instanceId,
+  runtimeId,
+  startTime,
+  nonce,
+}: {
+  instanceId: string
+  runtimeId: string
+  startTime: string
+  nonce: number
+}) {
+  const data = Buffer.from(`${runtimeId}:${startTime}:${nonce}`)
+  const computed = await crypto.subtle.digest('SHA-256', data)
+  return (
+    instanceId === Buffer.from(computed).toString('hex') &&
+    instanceId.substring(0, EXT_INSTANCE_ID_DIFFICULTY) ===
+      String().padStart(EXT_INSTANCE_ID_DIFFICULTY, '0')
+  )
+}


### PR DESCRIPTION
There was some data and processing missing from the API POST request. This branch adds those missing changes. The API POST request to register new extension instances now validates that the `instanceId` was properly generated by hashing the input data.