### PR TITLE
Set custom `endTime` for `getStatsPlatformRanked`

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -359,7 +359,15 @@ export default class Database {
       startTime = 'day'
     }
     if (!endTime) {
-      endTime = 'today'
+      switch (startTime) {
+        case 'today':
+          endTime = 'now'
+          break
+
+        default:
+          endTime = 'today'
+          break
+      }
     }
     if (!includeVotes) {
       includeVotes = false


### PR DESCRIPTION
If we want the top-ranked profiles/posts for today, then `endTime` must be `now` else no results will be returned.