### PR TITLE
Refactor `indexer.ts` to process `RankOutput` fields in a more effici…

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -339,7 +339,7 @@ export default class API extends EventEmitter {
       switch (postIdParams.type) {
         case 'BigInt': {
           const buffer = Buffer.from(BigInt(postId).toString(16), 'hex')
-          if (buffer.length != postIdParams.chunkLength) {
+          if (buffer.length != postIdParams.len) {
             return this.sendJSON(
               res,
               { error: `postId is invalid length` },


### PR DESCRIPTION
…ent manner

Use the defined `ScriptChunk` offsets in `rank-lib` to parse the transaction output script into the `RankOutput` object, rather than processing the buffers parsed by the bitcore lib.