### PR TITLE
Add `RuntimeState` module for indexer, api

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import Indexer from './lib/indexer'
 import API from './lib/api'
+import RuntimeState from './lib/state'
 import { log } from 'rank-lib'
 import {
   ERR,
@@ -14,12 +15,14 @@ type Exception = [number | string, string]
  */
 // Modules
 const db = new Database(process.env.DATABASE_URL)
+const state = new RuntimeState()
 const indexer = new Indexer(
+  state,
   db,
   String(process.argv[2] || NNG_PUB_DEFAULT_SOCKET_PATH), // /path/to/pub.pipe
   String(process.argv[3] || NNG_RPC_DEFAULT_SOCKET_PATH), // /path/to/rpc.pipe
 )
-const api = new API(db)
+const api = new API(state, db)
 // Startup/Shutdown functions
 const init = async () => {
   try {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -17,7 +17,7 @@ import {
 } from '@temporalio/client'
 import { Worker as TemporalWorker, NativeConnection } from '@temporalio/worker'
 import { Address, Message, Networks } from 'bitcore-lib-xpi'
-import { PLATFORMS, log, type ScriptChunkPlatformUTF8 } from 'rank-lib'
+import RuntimeState from './state'
 import Database, { type Timespan } from './database'
 import config from '../config'
 import { API_SERVER_PORT, ERR, HTTP } from '../util/constants'
@@ -105,14 +105,19 @@ export default class API extends EventEmitter {
   private app: Express
   private router: Router
   private server: Server
+  private state: RuntimeState
   private temporalClient!: TemporalClient
   private temporalWorker!: TemporalWorker
   /**
-   *
-   * @param db
+   * Initializes Express router with endpoints for profiles, posts, stats, and wallet operations
+   * Sets up parameter handlers and configures routes for both GET and POST requests
+   * @param state Runtime state for managing indexer state
+   * @param db Database instance for handling data operations
+   * @extends {EventEmitter} Inherits event handling capabilities
    */
-  constructor(db: Database) {
+  constructor(state: RuntimeState, db: Database) {
     super()
+    this.state = state
     this.db = db
     //this.app = express()
     this.router = Router({

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -1,0 +1,9 @@
+import type { Block } from 'rank-lib'
+
+export default class RuntimeState {
+  public checkpoint: Block
+
+  constructor() {
+    this.checkpoint = null
+  }
+}

--- a/schema.prisma
+++ b/schema.prisma
@@ -115,5 +115,6 @@ model ExtensionInstance {
   ranks         RankTransaction[]
 
   @@id([id, scriptPayload])
+  @@index([scriptPayload(type: hash)])
   @@index([id(type: hash), scriptPayload(type: hash), optin(type: hash)])
 }

--- a/util/constants.ts
+++ b/util/constants.ts
@@ -8,6 +8,7 @@ export const EXT_INSTANCE_ID_DIFFICULTY = 4
  */
 export const API_SERVER_PORT = 10655
 export const API_STATS_RESULT_COUNT = 5
+export const API_AUTH_CACHE_ENTRY_TTL = 420 // blocks over 1 day time span
 /**
  * NNG configuration
  */


### PR DESCRIPTION
This branch adds a new `RuntimeState` module that is instantiated during runtime init and passed to the indexer and api modules to share runtime state between them.

For now, the only state that is maintained during runtime is the checkpoint `Block`, i.e. the most recently indexed `Block`.