### PR TITLE
Add API endpoint for getting `RankTransaction`s

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/zboszor/node-nanomsg.git
 [submodule "rank-lib"]
 	path = submodules/rank-lib
-	url = https://github.com/LotusiaStewardship/rank-lib.git
+	url = git@github.com:LotusiaStewardship/rank-lib.git
 	branch = master
 [submodule "submodules/bitcore-lib-xpi"]
 	path = submodules/bitcore-lib-xpi

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -100,6 +100,7 @@ type Endpoint =
   | 'wallet'
   | 'charts'
   | 'search'
+  | 'txs'
 type EndpointHandler = (req: Request, res: Response) => void
 type EndpointParameter =
   | 'platform'
@@ -213,6 +214,7 @@ export default class API extends EventEmitter {
       '/:platform/:profileId/:postId/:scriptPayload',
       this.get.post,
     )
+    this.router.get('/txs/:platform/:profileId/:page?/:pageSize?', this.get.txs)
     this.router.get('/:platform/:profileId/:postId', this.get.post)
     this.router.get('/:platform/:profileId', this.get.profile)
     // Router POST endpoint configuration (DEEPEST ROUTES FIRST!)
@@ -891,6 +893,47 @@ export default class API extends EventEmitter {
         return this.sendJSON(
           res,
           { error: 'stats not found', params: req.params },
+          HTTP.NOT_FOUND,
+        )
+      }
+    },
+    /**
+     *
+     * @param req
+     * @param res
+     * @returns
+     */
+    txs: async (req: Request, res: Response) => {
+      const t0 = performance.now()
+      const { platform, profileId } = req.params
+      const page = Number(req.params.page)
+      const pageSize = Number(req.params.pageSize)
+      try {
+        const result = await this.db.apiGetPlatformProfileRankTransactions(
+          platform as ScriptChunkPlatformUTF8,
+          profileId,
+          page,
+          pageSize,
+        )
+        const t1 = (performance.now() - t0).toFixed(3)
+        log([
+          ['api', 'get.txs'],
+          ...this.toLogEntries(req.params),
+          ['elapsed', `${t1}ms`],
+        ])
+        return this.sendJSON(res, result, HTTP.OK)
+      } catch (e) {
+        const t1 = (performance.now() - t0).toFixed(3)
+        log([
+          ['api', 'error'],
+          ['action', 'get.txs'],
+          ...this.toLogEntries(req.params),
+          ['message', `"${String(e)}"`],
+          ['elapsed', `${t1}ms`],
+        ])
+        return this.sendJSON(
+          res,
+          { error: 'txs not found', params: req.params },
           HTTP.NOT_FOUND,
         )
       }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -497,6 +497,83 @@ export default class Database {
     })
   }
   /**
+   * Retrieves `RankTransaction`s for a specific `platform` and `profileId`
+   * @param platform The platform identifier (ScriptChunkPlatformUTF8)
+   * @param profileId The unique identifier of the profile
+   * @param page The page number to retrieve
+   * @param pageSize The number of transactions per page
+   * @returns Array of `RankTransaction`s
+   */
+  async apiGetPlatformProfileRankTransactions(
+    platform: ScriptChunkPlatformUTF8,
+    profileId: string,
+    page?: number,
+    pageSize?: number,
+  ) {
+    // Make sure parameters are set
+    if (!page) {
+      page = 1
+    }
+    if (!pageSize) {
+      pageSize = 10
+    }
+    if (page < 1) {
+      page = 1
+    }
+    if (pageSize > 40) {
+      pageSize = 40
+    }
+    try {
+      return await this.db.$transaction(async tx => {
+        const totalRanks = await tx.rankTransaction.count({
+          where: {
+            platform,
+            profileId,
+          },
+        })
+        const ranks = await tx.rankTransaction.findMany({
+          where: {
+            platform,
+            profileId,
+          },
+          orderBy: {
+            timestamp: 'desc',
+          },
+          // convert page to 0-based index
+          skip: (page - 1) * pageSize,
+          take: pageSize,
+          select: {
+            txid: true,
+            sentiment: true,
+            timestamp: true,
+            sats: true,
+            post: {
+              select: {
+                id: true,
+                ranking: true,
+              },
+            },
+          },
+        })
+        return {
+          votes: ranks.map(tx => ({
+            ...tx,
+            timestamp: tx.timestamp.toString(),
+            sats: tx.sats.toString(),
+            post: {
+              ...tx.post,
+              ranking: tx.post.ranking.toString(),
+            },
+          })),
+          numPages: Math.ceil(totalRanks / pageSize),
+        }
+      })
+    } catch (e) {
+      console.warn(e)
+      return { votes: [], numPages: 0 }
+    }
+  }
+  /**
    * Retrieves ranked statistics for a specific platform
    * @param dataType - The type of data to rank ('profileId' or 'postId')
    * @param rankingType - The ranking order ('top' or 'lowest')

--- a/schema.prisma
+++ b/schema.prisma
@@ -88,6 +88,7 @@ model RankTransaction {
   instance      ExtensionInstance? @relation(fields: [instanceId, scriptPayload], references: [id, scriptPayload])
 
   // Poll RANK txs for raw SQL queries
+  @@index([platform(type: hash), profileId(type: hash)])
   @@index([platform(type: hash), profileId(type: hash), sentiment(type: hash)])
   @@index([platform(type: hash), profileId(type: hash), postId(type: hash), sentiment(type: hash)])
   // Poll RANK txs by height (primarily for block rewinds)


### PR DESCRIPTION
This endpoint returns a paginated list of `RankTransaction`s for a given `platform` and `profileId`.