### PR TITLE
Always use `firstSeen`

### DIFF
--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -854,7 +854,7 @@ export default class Indexer extends EventEmitter {
       ranks.push({
         txid: tx.txid,
         outIdx: 0,
-        firstSeen: block ? undefined : BigInt(Date.now()),
+        firstSeen: BigInt(Date.now()),
         scriptPayload,
         height: block?.height, // undefined if mempool tx
         sats: BigInt(firstOutput.satoshis),
@@ -874,7 +874,7 @@ export default class Indexer extends EventEmitter {
         ranks.push({
           txid: tx.txid,
           outIdx: i,
-          firstSeen: block ? undefined : BigInt(Date.now()),
+          firstSeen: BigInt(Date.now()),
           scriptPayload,
           height: block?.height, // undefined if mempool tx
           sats: BigInt(output.satoshis),


### PR DESCRIPTION
This commit ensures that the `firstSeen` field is always set for `RankTransaction`s. This is helpful for ensuring that API requests for `RankTransaction` objects always return the results in a consistent order.