### PR TITLE
Add `profileId` to `orderBy`

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -819,6 +819,9 @@ export default class Database {
               timestamp: 'desc',
             },
             {
+              profileId: 'asc',
+            },
+            {
               firstSeen: {
                 sort: 'desc',
                 nulls: 'last',


### PR DESCRIPTION
Since the `firstSeen` timestamp is potentially the same between multiple OP_RETURN outputs in the same tx, we add a middle sort for `profileId` to add consistency to vote display in the dashboard.