### PR TITLE
Add a millisecond to subsequent outputs

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -819,9 +819,6 @@ export default class Database {
               timestamp: 'desc',
             },
             {
-              profileId: 'asc',
-            },
-            {
               firstSeen: {
                 sort: 'desc',
                 nulls: 'last',

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -874,7 +874,8 @@ export default class Indexer extends EventEmitter {
         ranks.push({
           txid: tx.txid,
           outIdx: i,
-          firstSeen: BigInt(Date.now()),
+          // Add a single millisecond to the current time to ensure the firstSeen is always greater than the first output
+          firstSeen: BigInt(Date.now() + 1),
           scriptPayload,
           height: block?.height, // undefined if mempool tx
           sats: BigInt(output.satoshis),


### PR DESCRIPTION
This is to ensure proper ordering, as outputs could be processed within the same millisecond, causing inconsistent ordering of results in API responses.

Also remove the `profileId` ordering in the database API query.