### PR TITLE
Only process `Post` relation if it exists

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -716,6 +716,7 @@ export default class Database {
           take: pageSize,
           select: {
             txid: true,
+            outIdx: true,
             sentiment: true,
             firstSeen: true,
             timestamp: true,


### PR DESCRIPTION
When fetching a `RankTransaction`, there may not always be a `Post` relation associated with it. This commit sets the conditional to ignore nonexistent `Post` relations when fetching `RankTransaction` objects via the API `apiGetPlatformProfileRankTransactions` method of the `Database` class.