### PR TITLE
Properly validate `profileId`

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -457,14 +457,11 @@ export default class API extends EventEmitter {
     ) => {
       profileId = profileId.toLowerCase()
       const platform = req.params.platform as ScriptChunkPlatformUTF8
-      const platformParams = this.app.get(
-        'platformParams',
-      ) as typeof PlatformConfiguration
-      const { profileId: profileIdParams } = platformParams.get(platform)
-      if (profileId.length > profileIdParams.len) {
+      // toProfileIdBuf will return null if the profileId is invalid
+      if (toProfileIdBuf(platform, profileId) === null) {
         return this.sendJSON(
           res,
-          { error: `profileId is invalid length` },
+          { error: `invalid profileId specified` },
           HTTP.BAD_REQUEST,
         )
       }


### PR DESCRIPTION
This commit ensures that the `profileId` param validator in the API can accommodate multiple platforms. It now uses the `toProfileIdBuf` function to check if the provided `profileId` string is valid depending on the platform provided.