### PR TITLE
feat(core): engagement accounting, RNKE spec; DB schema & API rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ RANK_GENESIS_HEIGHT=952169
 # Hash of the RANK genesis block
 RANK_GENESIS_HASH=0000000000c974cb635064bec0db8cc64a75526871f581ea5dbeca7a98551546
 
+# Rate limiting configuration
+API_RATE_LIMIT_WINDOW_MINUTES=1
+API_RATE_LIMIT_MAX_REQUESTS=1000
+
 # Referral System
 # Secret key used for HMAC signing of referral codes
 REFERRAL_SECRET=your-referral-hmac-secret-here

--- a/README.md
+++ b/README.md
@@ -2,102 +2,177 @@
 
 ### **Tested on openSUSE Tumbleweed x86_64 with NodeJS 20.18.0+**
 
-`rank-backend-ts` connects to the Lotus blockchain daemon using NNG (via npm `nanomsg` library) in order to index all transactions containing a valid RANK output. RANK outputs are indexed into a PostgreSQL database. Retrieving records from this database is made possible by the built-in REST API library.
+`rank-backend-ts` connects to the Lotus blockchain daemon using NNG (via `nanomsg`) in order to index transactions containing valid RANK/RNKC outputs into PostgreSQL. That indexed state is then exposed through HTTP APIs for wallet/extension/app consumers.
 
-`rank-backend-ts` is _fast_. Benchmarks performed on moderate hardware show a transaction processing rate of over 6,900 RANK tx/s during initial sync. During runtime, the indexer will queue NNG messages and process them in the order they were received, ensuring the state of the index remains intact.
+`rank-backend-ts` is designed for high-throughput indexing. During runtime, NNG messages are queued and processed in order to preserve index consistency.
 
-As of v0.1.0, `rank-backend-ts` is considered **stable** and **performant**. Implementing parallelization through `worker_threads` isn't planned at this time, but we will revist `worker_threads` in the future if the RANK protocol evolves and requires the indexer to evolve with it.
+As of v0.1.0, `rank-backend-ts` has been considered stable/performant. `worker_threads` parallelization is intentionally not used right now, but can be revisited if protocol/runtime needs evolve.
 
-**\*\*\*** **For best indexing performance, run lotusd, PostgreSQL, and `rank-backend-ts` on the same host**
+**For best indexing performance, run `lotusd`, PostgreSQL, and `rank-backend-ts` on the same host.**
 
-# Prerequisites
+---
 
-- Configure lotusd – refer to [`raipay/chronik` setup instructions](https://github.com/raipay/chronik#setting-up-ecash-or-lotus-node-for-chronik)
-- Clone `rank-backend-ts` repo:
+## What runs at runtime
 
-  ```
-  git clone --recurse-submodules https://github.com/LotusiaStewardship/rank-backend-ts.git
-  ```
+The process boots and runs these modules together:
 
-### PostgreSQL - Linux
+1. **Indexer**
+   - Reconciles checkpoint state with chain tip
+   - Syncs historical blocks + mempool
+   - Subscribes to runtime NNG channels:
+     - `mempooltxadd`
+     - `mempooltxrem`
+     - `blkconnected`
+     - `blkdisconctd`
 
-**NOTE: These instructions were tested on openSUSE Tumbleweed and are working as of October 23, 2024**
+2. **REST API**
+   - Express server at `/api/v1`
+   - Listens on port `10655`
 
-1. Install `postgresql-server` using your system's package manager (package name may differ depending on your distribution)
-2. Open a terminal **with `root` privileges** and change to the directory where you cloned `rank-backend-ts`
-3. Enable password authentication on PostgreSQL for localhost (if not already enabled):
+3. **Push API**
+   - Express server at `/push`
+   - Listens on port `3001`
 
-   ```
-   sudo -u postgres sed -rn -i.bak 'p; s/(host\s+all.*127\.0\.0\.1\/32\s+)password!/\1password/p' /var/lib/pgsql/data/pg_hba.conf
-   ```
+4. **Temporal integration**
+   - Initialized at startup
+   - Some features are workflow/query-backed and require a working Temporal config/server
 
-4. Start (or restart) PostgreSQL service:
+Startup order is:
 
-   ```
-   systemctl restart postgresql.service
-   ```
+1. DB connect → 2. push cache init → 3. indexer init/sync → 4. REST API init → 5. push API init → 6. Temporal init.
 
-   You should see that the sevice is `active (running)`
+Graceful shutdown is handled on `SIGINT` / `SIGTERM`.
 
-   ```
-   ● postgresql.service - PostgreSQL database server
-       Loaded: loaded (/usr/lib/systemd/system/postgresql.service; enabled; preset: disabled)
-       Active: active (running) since Fri 2024-10-18 10:18:46 CDT; 4 days ago
-   ```
+---
 
-5. Execute the database setup script:
-   ```
-   sudo -u postgres psql -f install/rank-index.sql
-   ```
+## Prerequisites
 
-\*\*\* **IMPORTANT: The location of `pg_hba.conf` will vary depending on your distribution**
+- Configure lotusd (NNG sockets enabled) (refer to [`raipay/chronik` setup instructions](https://github.com/raipay/chronik#setting-up-ecash-or-lotus-node-for-chronik))
+- Node.js 20+
+- PostgreSQL
+- Optional: Temporal server (required for workflow-backed features)
 
-# Install – Docker
+Clone with submodules:
 
-**COMING SOON**
-
-# Install – Linux / macOS
-
-**NOTE: There is currently no plan to support Windows**
-
-1. Open a terminal and change to the directory where you cloned `rank-backend-ts`
-2. Install prod and dev dependencies:
-
-   ```
-   npm install --include=dev
-   ```
-
-3. Apply Prisma schema to PostgreSQL and generate runtime client artifacts:
-
-   ```
-   npx prisma db push
-   ```
-
-4. Clean install to remove dev dependencies (`omit=dev` is defined in `.npmrc`):
-
-   ```
-   npm clean-install
-   ```
-
-5. Start the indexer:
-
-   ```
-   npx tsc && node scripts/start [pub socket path] [rpc socket path]
-   ```
-
-   Example:
-
-   ```
-   npx tsc && node scripts/start ~/.lotus/pub.pipe ~/.lotus/rpc.pipe
-   ```
-
-   **NOTE: If no command-line arguments are provided, the indexer will attempt to connect to `ipc://~/.lotus/pub.pipe` and `ipc://~/.lotus/rpc.pipe`**
-
-# Runtime
-
-Once the indexer is running, you will begin to see scrolling messages with `init=syncBlocks`. After the initial block sync, the mempool will be synced and the NNG sub socket will begin listening for new events.
-
+```bash
+git clone --recurse-submodules https://github.com/LotusiaStewardship/rank-backend-ts.git
+cd rank-backend-ts
 ```
+
+---
+
+## PostgreSQL setup (Linux example)
+
+> These are historical openSUSE instructions preserved from prior docs. Adapt paths/service names for your distro.
+
+1. Install `postgresql-server` using your package manager.
+2. Enable password auth on localhost if needed (edit `pg_hba.conf`).
+3. Start/restart PostgreSQL.
+4. Execute bootstrap SQL:
+
+```bash
+sudo -u postgres psql -f install/rank-index.sql
+```
+
+`install/rank-index.sql` creates a `lotusrank` role/db/schema. You can also provision DB/role manually.
+
+Then apply Prisma schema:
+
+```bash
+npx prisma db push
+```
+
+---
+
+## Install / Build / Start
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Build TypeScript output to `.output/`:
+
+```bash
+npm run build:dev
+```
+
+Production build flow:
+
+```bash
+npm run build:prod
+```
+
+Start service (`.env` loaded by `dotenv-cli` in the start script):
+
+```bash
+npm start
+```
+
+Start with explicit NNG socket paths:
+
+```bash
+npm start -- /absolute/path/to/pub.pipe /absolute/path/to/rpc.pipe
+```
+
+If no CLI args are provided, defaults are:
+
+- `~/.lotus/pub.pipe`
+- `~/.lotus/rpc.pipe`
+
+---
+
+## Environment variables
+
+Configured via `.env` (see `.env.example` in local checkout).
+
+### Core
+
+| Variable              | Description                                               |
+| --------------------- | --------------------------------------------------------- |
+| `DATABASE_URL`        | PostgreSQL connection string                              |
+| `RANK_GENESIS_HEIGHT` | Genesis height used when DB checkpoint does not yet exist |
+| `RANK_GENESIS_HASH`   | Genesis hash paired with `RANK_GENESIS_HEIGHT`            |
+
+### Referral / admin
+
+| Variable          | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `REFERRAL_SECRET` | HMAC secret used for referral code generation |
+| `ADMIN_SECRET`    | Shared secret for admin referral endpoints    |
+
+### Push notifications
+
+| Variable            | Description                |
+| ------------------- | -------------------------- |
+| `VAPID_SUBJECT`     | Web Push VAPID subject     |
+| `VAPID_PUBLIC_KEY`  | Web Push VAPID public key  |
+| `VAPID_PRIVATE_KEY` | Web Push VAPID private key |
+| `GCM_API_KEY`       | Optional legacy GCM key    |
+
+### Temporal
+
+| Variable                                         | Description                                    |
+| ------------------------------------------------ | ---------------------------------------------- |
+| `TEMPORAL_HOST`                                  | Temporal address (e.g. `localhost:7233`)       |
+| `TEMPORAL_NAMESPACE`                             | Temporal namespace                             |
+| `TEMPORAL_TASKQUEUE`                             | Worker task queue                              |
+| `TEMPORAL_COMMAND_WORKFLOW_TYPE`                 | Workflow type for command signaling            |
+| `TEMPORAL_COMMAND_WORKFLOW_ID`                   | Workflow ID for command signaling              |
+| `TEMPORAL_COMMAND_WORKFLOW_SIGNAL`               | Signal name for command signaling              |
+| `TEMPORAL_API_CHARTS_WALLET_ACTIVITY`            | Workflow ID queried for wallet activity charts |
+| `TEMPORAL_API_CHARTS_WALLET_ACTIVITY_QUERY_TYPE` | Query type prefix used for chart query names   |
+
+> Temporal-backed endpoints/features require this config and a reachable Temporal server.
+
+---
+
+## Runtime logs and event examples
+
+Once the indexer is running, you'll see init messages (`syncBlocks`, `syncMempool`, subscriptions, API listeners):
+
+```text
 .. snip ..
 2024-11-23T11:21:21.301Z init=syncBlocks status=finished totalBlocks=0 totalRanks=0 elapsed=0.000s
 2024-11-23T11:21:21.326Z init=syncMempool txsLength=27 ranksLength=27 action=upsertProfiles elapsed=24.528ms
@@ -107,7 +182,7 @@ Once the indexer is running, you will begin to see scrolling messages with `init
 
 ### Example NNG events
 
-```
+```text
 # mempooltxadd
 2024-11-23T11:23:10.265Z nng=mempooltxadd txid=dabd3946ecf0a01af3792357e6f3c9bf7e98041428c87d32b478f6189b15eaa5 timestamp=1732360990 sats=1000000 sentiment=negative platform=twitter profileId=caincurrency postId=1859129590142153145 action=upsertProfiles elapsed=3.177ms
 
@@ -121,20 +196,41 @@ Once the indexer is running, you will begin to see scrolling messages with `init
 2024-11-11T13:20:59.918Z nng=blkdisconctd hash=000000000205072f83f59100bda1dd1c29763c703a447ae22b75a7ef4ec62683 height=895465 timestamp=1731331231 ranksLength=0 txsLength=0 action=rewindBlock elapsed=1.872ms
 ```
 
-### NNG Event Field Index
+### NNG Event Field Index (current runtime)
 
-| Field          | Description                                                     |
-| -------------- | --------------------------------------------------------------- |
-| `nng=`         | Indicates an NNG event and which type                           |
-| `txid=`        | txid containing the RANK output                                 |
-| `hash=`        | Block hash                                                      |
-| `height=`      | Block height                                                    |
-| `ranksLength=` | Number of RANK outputs in the block                             |
-| `txsLength=`   | Number of total transactions in the block                       |
-| `timestamp=`   | If mempool, current time; if block, timestamp in block header   |
-| `platform=`    | String indicating target platform (e.g. `twitter`)              |
-| `profileId=`   | String of profile name, decoded from hex                        |
-| `sentiment=`   | String indicating sentiment (e.g. `positive`, `negative`, etc.) |
-| `sats=`        | Number of satoshis burned in the RANK output                    |
-| `action=`      | Indexer action taken for the init stage or received NNG message |
-| `elapsed=`     | Time taken to process the `action=`                             |
+> Note: `nng=*` log fields are event-specific; not every field appears on every event.
+
+| Field              | Appears in                                     | Description                                                                                                            |
+| ------------------ | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `nng=`             | all NNG logs                                   | NNG event type (`mempooltxadd`, `mempooltxrem`, `blkconnected`, `blkdisconctd`, or `warn`)                             |
+| `txid=`            | `mempooltxadd`, `mempooltxrem`                 | Transaction ID tied to the mempool event                                                                               |
+| `hash=`            | `blkconnected`, `blkdisconctd`                 | Block hash                                                                                                             |
+| `height=`          | `blkconnected`, `blkdisconctd`                 | Block height                                                                                                           |
+| `timestamp=`       | `blkconnected`, `blkdisconctd`                 | Block header timestamp                                                                                                 |
+| `ranksLength=`     | `mempooltxadd`, `blkconnected`, `blkdisconctd` | Count of parsed RANK outputs for that event context                                                                    |
+| `rnkcsLength=`     | `blkconnected`, `blkdisconctd`                 | Count of parsed RNKC outputs for that block context                                                                    |
+| `isComment=`       | `mempooltxadd`                                 | Whether an RNKC comment payload was detected in the tx (`true`/`false`)                                                |
+| `outpointsLength=` | `mempooltxrem`                                 | Number of cached outpoints removed for that txid                                                                       |
+| `txsLength=`       | `blkdisconctd`                                 | Number of transactions rewound when disconnecting the block                                                            |
+| `action=`          | all NNG logs                                   | Handler action performed (e.g. `upsertProfiles`, `rewindProfiles`, `saveBlock`, `rewindBlock`, `checkFaucetMilestone`) |
+| `elapsed=`         | success-path NNG handlers                      | Processing time for the logged action                                                                                  |
+| `scriptPayload=`   | `nng=warn` (faucet milestone check)            | Wallet script payload associated with the warning                                                                      |
+| `message=`         | `nng=warn`                                     | Warning/error message text                                                                                             |
+
+---
+
+## API / specs / utility scripts
+
+- HTTP API reference: [`docs/API.md`](./docs/API.md)
+- Protocol specs:
+  - [`docs/spec/RANK.md`](./docs/spec/RANK.md)
+  - [`docs/spec/RNKC.md`](./docs/spec/RNKC.md)
+  - [`docs/spec/RNKE.md`](./docs/spec/RNKE.md)
+
+Backfill wallet engagement data:
+
+```bash
+npx tsx scripts/backfill-engagement.ts
+```
+
+(Backfill script is idempotent and safe to re-run.)

--- a/config.ts
+++ b/config.ts
@@ -5,6 +5,10 @@ type TemporalWorkflowQuery = {
 }
 type ParsedConfig = {
   datasourceUrl: string
+  api: {
+    rateLimitWindowMinutes: number
+    rateLimitMaxRequests: number
+  }
   genesis: {
     height: number
     hash: string
@@ -53,6 +57,14 @@ class Config {
   private parseConfig(): ParsedConfig {
     return {
       datasourceUrl: this.env.parsed?.DATABASE_URL,
+      api: {
+        rateLimitWindowMinutes: parseInt(
+          this.env?.parsed?.API_RATE_LIMIT_WINDOW_MINUTES || '1',
+        ),
+        rateLimitMaxRequests: parseInt(
+          this.env?.parsed?.API_RATE_LIMIT_MAX_REQUESTS || '1000',
+        ),
+      },
       genesis: {
         height: parseInt(this.env.parsed?.RANK_GENESIS_HEIGHT),
         hash: this.env.parsed?.RANK_GENESIS_HASH,

--- a/docs/spec/RNKE.md
+++ b/docs/spec/RNKE.md
@@ -1,0 +1,533 @@
+# RNKE Protocol Specification
+
+## Overview
+
+The **RNKE** (RANK Comment Edit) protocol is a Lotus OP\_RETURN-based protocol for applying incremental edits to existing RNKC comment transactions. It uses the LOKAD prefix `0x524e4b45` ("RNKE" in ASCII) to identify transactions that implement this protocol.
+
+Because RNKC transactions are immutable once confirmed on the blockchain, a user who burns Lotus to publish an RNKC comment has no on-chain mechanism to modify its text. RNKE resolves this by allowing the original author to broadcast a supplementary transaction that encodes a **Run-Length Skip/Write (RLSW)** patch against the original RNKC comment. Indexers that support RNKE reconstruct the edited comment by applying the patch to the source text retrieved from the referenced RNKC transaction.
+
+RNKE is a **supplement** to the RNKC protocol, not a replacement. An RNKE transaction is only valid in relation to an existing, indexed RNKC transaction, and the edit chain is always rooted in an original RNKC transaction.
+
+## LOKAD Prefix
+
+- **Prefix**: `0x524e4b45` (4 bytes, big-endian)
+- **ASCII Representation**: "RNKE"
+- **Version**: v1
+
+## Relationship with RNKC Protocol
+
+RNKE is designed to extend RNKC without altering it. The following invariants govern the relationship between the two protocols:
+
+- An RNKE transaction **must** reference exactly one RNKC transaction by its `txid`.
+- The referenced RNKC transaction must be fully confirmed and indexed before the RNKE transaction is processed.
+- An RNKE transaction **must** be signed by the same key that funded the referenced RNKC transaction's inputs, establishing authorship continuity.
+- Multiple RNKE transactions may reference the same RNKC transaction. The **most recent valid RNKE** (by block height, then by transaction index within the block) is the canonical edit. Earlier RNKE transactions against the same RNKC `txid` are superseded.
+- An RNKE transaction **may** reference a previous RNKE transaction as its source instead of the original RNKC transaction, enabling chained edits. In this case, the `source_txid` field refers to the RNKE transaction being amended, and the patch is applied to that RNKE's resolved output text. The chain always terminates at the original RNKC transaction. Indexers **must** resolve the full chain to reconstruct the current canonical text.
+- A single RNKE transaction establishes one discrete revision. There is no batch-edit operation.
+
+## Transaction Structure
+
+An RNKE transaction requires exactly **2 OP\_RETURN outputs** and may include an optional **3rd OP\_RETURN output** if the patch payload exceeds 220 bytes:
+
+- **Output 0**: Metadata (LOKAD prefix, platform, profile ID, source txid, source CRC32)
+- **Output 1**: Patch data (first chunk, up to 220 bytes)
+- **Output 2** (optional): Patch data (second chunk, up to 220 bytes)
+
+### Multi-Output Layout
+
+```
+Output 0: [OP_RETURN] [PUSH 4] [LOKAD] [PUSH 1] [PLATFORM] [PUSH N] [PROFILE_ID] [PUSH 32] [SOURCE_TXID] [PUSH 4] [SOURCE_CRC32]
+Output 1: [OP_RETURN] [OP_PUSHDATA1] [LENGTH] [PATCH_DATA_1]
+Output 2: [OP_RETURN] [OP_PUSHDATA1] [LENGTH] [PATCH_DATA_2]  (optional)
+```
+
+### Output 0: Metadata
+
+| Offset | Length | Field | Description |
+| --- | --- | --- | --- |
+| 0 | 1 | OP\_RETURN | `0x6a` — OP\_RETURN opcode |
+| 1 | 1 | PUSH OP | `0x04` — Push 4 bytes |
+| 2–5 | 4 | LOKAD Prefix | `0x524e4b45` — "RNKE" |
+| 6 | 1 | PUSH OP | `0x01` — Push 1 byte |
+| 7 | 1 | Platform | Platform identifier (see Platform Codes) |
+| 8 | 1 | PUSH OP | Platform-specific profile ID length |
+| 9+ | Variable | Profile ID | Platform-specific profile identifier |
+| ... | 1 | PUSH OP | `0x20` — Push 32 bytes |
+| ... | 32 | Source TXID | `txid` of the RNKC (or prior RNKE) transaction being edited, in **little-endian** byte order |
+| ... | 1 | PUSH OP | `0x04` — Push 4 bytes |
+| ... | 4 | Source CRC32 | CRC-32/ISO-HDLC checksum of the **source comment bytes** (the UTF-8 encoded text as stored, prior to patching), big-endian |
+
+#### Source TXID Encoding
+
+The `source_txid` field is the raw 32-byte transaction hash in **internal byte order** (little-endian), consistent with how transaction IDs are stored and referenced throughout the Lotus/Bitcoin Cash ecosystem. Indexers must display or log the `txid` in **reversed byte order** (big-endian) for human-readable output.
+
+#### Source CRC32
+
+The `source_crc32` field is a CRC-32/ISO-HDLC (standard CRC-32 as used in Ethernet, zlib, PNG) checksum of the exact bytes of the source comment text — that is, the concatenated UTF-8 bytes of the comment as resolved from the referenced transaction — prior to applying the RNKE patch. The checksum is encoded as a 4-byte big-endian unsigned integer.
+
+This field serves as a safety guard: if the checksum of the fetched source text does not match `source_crc32`, the indexer **must reject** the RNKE transaction as invalid and **must not** apply the patch. This prevents patch misapplication in edge cases such as:
+
+- Chain reorganizations that alter the referenced transaction's content
+- Indexer state inconsistency
+- An RNKE transaction constructed against a chained RNKE that has itself been superseded
+
+### Output 1 & 2: Patch Data
+
+| Offset | Length | Field | Description |
+| --- | --- | --- | --- |
+| 0 | 1 | OP\_RETURN | `0x6a` — OP\_RETURN opcode |
+| 1 | 1 | OP\_PUSHDATA1 | `0x4c` — Push up to 255 bytes |
+| 2 | 1 | Data Length | Number of bytes to push (1–220) |
+| 3+ | Variable | Patch Data | RLSW-encoded patch payload (see Patch Encoding) |
+
+Patch data from Output 1 and Output 2 is concatenated in order before parsing:
+
+```
+Patch Payload = Output1PatchData + Output2PatchData
+```
+
+The concatenated payload is then parsed as a sequence of RLSW records from left to right.
+
+## Platform Codes
+
+RNKE inherits the platform code definitions from RNKC without modification:
+
+| Platform | Code | Hex Value | Profile ID Format | Notes |
+| --- | --- | --- | --- | --- |
+| Lotusia | 0 | `0x00` | 20-byte P2PKH address (hex) | Profile must match RNKC source |
+| Twitter/X | 1 | `0x01` | 1–16 character username (UTF-8) | Profile must match RNKC source |
+
+The `platform` and `profile_id` fields in Output 0 of the RNKE transaction **must** be identical to those in the referenced RNKC transaction's Output 0. An RNKE transaction that specifies a different platform or profile ID than its source is invalid and must be rejected.
+
+## Patch Encoding: Run-Length Skip/Write (RLSW)
+
+The RLSW encoding describes edits to the source comment as a sequential stream of records. Each record instructs the indexer to advance through the source string and optionally overwrite bytes. Unvisited bytes at the tail of the source string are implicitly preserved. The encoding is read from left to right; records must be applied strictly in the order they appear.
+
+### Record Format
+
+Each RLSW record has the following structure:
+
+```
+[2 bytes: skip_count] [1 byte: write_length] [write_length bytes: write_data]
+```
+
+| Field | Size | Type | Description |
+| --- | --- | --- | --- |
+| `skip_count` | 2 bytes | BE uint16 | Number of bytes to advance the source cursor without modification. `0xFFFF` is the **terminator sentinel** (see below). |
+| `write_length` | 1 byte | uint8 | Number of bytes to write (and simultaneously consume from the source). `0x00` indicates a pure skip with no replacement. |
+| `write_data` | `write_length` bytes | raw bytes | UTF-8 encoded replacement text. Present only when `write_length > 0`. |
+
+### Terminator Sentinel
+
+A record with `skip_count = 0xFFFF` signals the end of the patch stream. Upon encountering this sentinel, the indexer **must** emit all remaining source bytes from the current cursor position to the end of the source string, then halt processing. The terminator's `write_length` byte **must** be `0x00` and **must** be present; any `write_length` value other than `0x00` following a `0xFFFF` skip is invalid and the RNKE transaction must be rejected.
+
+A terminator sentinel is **required** when the patch does not modify or visit all bytes through the end of the source string (i.e., when trailing bytes must be preserved implicitly). It is **optional** if the patch explicitly covers every byte of the source string with skip and write records that together account for all source bytes.
+
+### Reconstruction Algorithm
+
+The following pseudocode describes patch application. `src` is the UTF-8 byte array of the source comment; `patch` is the concatenated RLSW payload bytes; `out` is the output buffer.
+
+```
+src_cursor  ← 0
+patch_cursor ← 0
+out ← []
+
+while patch_cursor < len(patch):
+    skip_count   ← BE_uint16(patch[patch_cursor : patch_cursor + 2])
+    patch_cursor ← patch_cursor + 2
+
+    if skip_count == 0xFFFF:
+        write_length ← patch[patch_cursor]
+        patch_cursor ← patch_cursor + 1
+        if write_length != 0x00:
+            REJECT transaction
+        out.append(src[src_cursor :])   // emit remaining source tail
+        break
+
+    write_length ← patch[patch_cursor]
+    patch_cursor ← patch_cursor + 1
+
+    // Emit the skipped source bytes unchanged
+    out.append(src[src_cursor : src_cursor + skip_count])
+    src_cursor ← src_cursor + skip_count
+
+    if write_length > 0:
+        write_data   ← patch[patch_cursor : patch_cursor + write_length]
+        patch_cursor ← patch_cursor + write_length
+
+        // Consume source bytes that are being replaced
+        src_cursor   ← src_cursor + write_length
+
+        // Emit replacement bytes
+        out.append(write_data)
+
+// If patch stream ended without a terminator and src_cursor < len(src),
+// emit the remaining source tail implicitly.
+if src_cursor < len(src):
+    out.append(src[src_cursor :])
+```
+
+After reconstruction, the output buffer must be validated as well-formed UTF-8. If it is not, the RNKE transaction must be rejected.
+
+### Length Constraints on Reconstructed Text
+
+The reconstructed comment text (after patch application) is subject to the same length constraints as an original RNKC comment:
+
+- **Minimum Length**: 1 byte (configurable, matching the RNKC minimum)
+- **Maximum Length**: 440 bytes
+
+An RNKE transaction that would produce a reconstructed comment outside these bounds is invalid and must be rejected.
+
+### RLSW Design Notes
+
+- Records are strictly sequential; there is no random-access addressing. All operations progress left-to-right through the source string.
+- **Insertions** (growing the comment) are expressed as a record with `skip_count = 0` and `write_length > 0`, where `write_length` bytes of `write_data` replace zero source bytes. Because `skip_count = 0` means no source bytes are consumed before writing, and `write_length` bytes of source are consumed during the write step: a net insertion requires `write_length` bytes of new content to be written while consuming `write_length` source bytes. To insert **without** consuming source bytes, use `write_length = 0` (pure skip of 0) followed by a separate record.
+
+  > **Clarification — pure insertion:** To insert new text between two source positions without replacing any source bytes, emit a record with `skip_count` equal to the offset of the insertion point (to advance the cursor there), `write_length = 0` (no replacement), and then immediately follow with another record where `skip_count = 0` and `write_length > 0`, with `write_data` containing the inserted text, and source bytes consumed by `write_length` set to 0. This requires the two-record sequence:
+  >
+  > ```
+  > [offset] [00]          // advance to insertion point, no replacement
+  > [0000]   [N] [data]   // write N bytes, consume 0 source bytes
+  > ```
+  >
+  > However, a simpler model is that `write_length` always consumes that many source bytes. **Pure insertion (no consumption)** is therefore modeled as `write_length = 0` on the advance record, and the payload record uses `skip_count = 0` with `write_length > 0` consuming source bytes that are intended to remain. If a true zero-consumption insert is needed (e.g., inserting text before the first character without overwriting it), the implementer **must** re-encode the first character(s) into `write_data` along with the inserted text, adjusting `write_length` accordingly.
+
+- **Deletions** (shrinking the comment) are expressed as a record with `skip_count` advancing to the deletion site, `write_length = 0` (no replacement data written), and the source cursor advanced by the number of bytes to delete. Because `write_length = 0` means no write data follows, the bytes at `src[src_cursor : src_cursor + delete_count]` are simply not emitted. In practice, deletions are encoded by **not emitting** those bytes: the skip advances the cursor past the deleted region with no write. This means deletion requires a following record (or terminator) that skips past the deleted bytes by having the *next* skip_count begin after them — **or** by using `write_length = 0` on a record that sits at the deletion site with `skip_count` advancing to just before it, and then consuming the deleted bytes with the next record's `write_length = 0` and no write_data.
+
+  > **Simplified deletion model:** The cleanest way to delete bytes `[A, B)` from the source is a two-record sequence:
+  >
+  > ```
+  > [A]      [0]           // skip to start of deleted region, no write
+  > [0000]   [0]           // skip_count=0, write_length=0, then advance src_cursor by (B-A) in the next step
+  > ```
+  >
+  > Given the ambiguity above, the **canonical deletion encoding** for RNKE v1 is: advance the src_cursor to position A via `skip_count = A`, then encode the deleted byte count implicitly by having the following record's `skip_count` begin at position B. That is, the record at position A simply has `write_length = 0` with `skip_count` pointing past the deleted bytes, meaning the deleted bytes are never emitted. Indexers must treat any bytes between the last emitted skip region and the next skip's start as consumed/deleted.
+
+- **Replacements** (same-length or different-length substitution) are the most natural operation: advance to the target position with `skip_count`, set `write_length` to the number of source bytes being replaced, and provide `write_data` with the replacement text. `write_data` may be longer or shorter than the replaced region.
+
+- The total byte length of all RLSW records (including all headers and `write_data` payloads) must not exceed 440 bytes (the combined capacity of Outputs 1 and 2).
+
+## Fee Rate Validation
+
+RNKE transactions must meet a minimum fee rate requirement, calculated against the **patch payload size** (the total bytes of RLSW-encoded data across Outputs 1 and 2), not the reconstructed comment length.
+
+### Calculation
+
+```
+Minimum Fee Rate   = RNKE.minFeeRate (satoshis per byte)
+Required Satoshis  = Minimum Fee Rate × Patch Payload Length (bytes)
+Actual Satoshis Burned = Sum of all output values
+```
+
+### Validation Rule
+
+```
+Actual Satoshis Burned ≥ Required Satoshis
+```
+
+### Default Configuration
+
+- **Minimum Fee Rate**: 10,000,000 satoshis per byte (10 XPI per byte), matching the RNKC default
+- **Minimum Patch Length**: 3 bytes (the minimum possible RLSW record: 2-byte skip + 1-byte write_length)
+
+### Fee Examples
+
+| Patch Payload Length | Satoshis Required | XPI Required |
+| --- | --- | --- |
+| 3 bytes (1 op, minimal) | 30,000,000 | 30 XPI |
+| 11 bytes (1 op, 8-byte replacement) | 110,000,000 | 110 XPI |
+| 50 bytes | 500,000,000 | 500 XPI |
+| 220 bytes | 2,200,000,000 | 2,200 XPI |
+| 440 bytes | 4,400,000,000 | 4,400 XPI |
+
+Note that the fee for a typical single-word edit (a replacement record of roughly 11–20 bytes) is substantially lower than the cost of re-broadcasting the entire comment as a new RNKC transaction.
+
+## Validation Rules
+
+### Required Fields
+
+- **Platform**: Must be a supported platform code (`0x00` or `0x01`)
+- **Profile ID**: Must match platform-specific format, length, and encoding requirements
+- **Source TXID**: Must be a 32-byte value referencing a confirmed, indexed RNKC or RNKE transaction
+- **Source CRC32**: Must match the CRC-32/ISO-HDLC checksum of the source comment bytes
+- **Patch Data**: Must be a valid, parseable RLSW byte stream
+
+### Output Requirements
+
+- **Output 0**: Must be a valid OP\_RETURN with RNKE LOKAD prefix, correct metadata fields in order
+- **Output 1**: Must be a valid OP\_RETURN with at least 3 bytes of patch data
+- **Output 2**: Optional; must be a valid OP\_RETURN with patch data if present
+- **Output Count**: Minimum 2, maximum 3 OP\_RETURN outputs
+
+### Authorship Validation
+
+The RNKE transaction must be funded by at least one UTXO whose locking script corresponds to the same address that funded the original RNKC transaction's inputs. Indexers must verify that the spending address of at least one RNKE input matches at least one RNKC input address. If authorship cannot be confirmed, the RNKE transaction must be rejected.
+
+### Patch Validity
+
+- **Parseable**: The RLSW byte stream must be fully parseable without buffer overruns
+- **UTF-8 Output**: The reconstructed comment must be valid UTF-8
+- **Length Bounds**: The reconstructed comment must be between 1 and 440 bytes (inclusive)
+- **CRC32 Match**: The source comment bytes must match `source_crc32` before the patch is applied
+- **Terminator Integrity**: If a terminator sentinel (`0xFFFF`) is present, its accompanying `write_length` must be `0x00`
+
+### Cross-Field Consistency
+
+- `platform` and `profile_id` in the RNKE Output 0 must exactly match those in the referenced source transaction's Output 0
+- If the source is an RNKE transaction (chained edit), the platform and profile ID are compared against that RNKE transaction's Output 0, which itself must have matched the original RNKC chain
+
+## Example Transactions
+
+### Example 1: Single-Word Replacement
+
+**Scenario**: The original RNKC comment is `"This project is bad and you should feel bad."` (45 bytes). The author wishes to change the first `"bad"` (bytes 16–18) to `"great"`.
+
+**Source CRC32**: Computed over the 45 UTF-8 bytes of the original comment. For illustration, assume the result is `0xA1B2C3D4`.
+
+**RLSW Patch Construction**:
+
+```
+Record 1: skip 16 bytes, replace 3 bytes with "great" (5 bytes)
+  skip_count   = 0x0010
+  write_length = 0x05
+  write_data   = 6772656174 ("great")
+
+Terminator:
+  skip_count   = 0xFFFF
+  write_length = 0x00
+```
+
+**Patch payload** (hex):
+```
+0010 05 6772656174 FFFF 00
+```
+Total: 2 + 1 + 5 + 2 + 1 = **11 bytes**
+
+**Output 0** (Lotusia platform, 20-byte profile ID `1234...5678`, source txid `abcd...ef01`):
+```
+6a
+04 524e4b45
+01 00
+14 1234567890abcdef1234567890abcdef12345678
+20 01efcdab...  (32-byte source txid, little-endian)
+04 a1b2c3d4     (source CRC32)
+```
+
+**Output 1**:
+```
+6a 4c 0b 001005677265616174ffff00
+```
+
+**Reconstructed Comment**: `"This project is great and you should feel bad."`
+
+---
+
+### Example 2: Typo Fix (Character Transposition)
+
+**Scenario**: Original RNKC comment is `"The quikc brown fox jumps over the lazy dog."` (45 bytes). Author wishes to correct `"quikc"` (bytes 4–8) to `"quick"`.
+
+**RLSW Patch Construction**:
+
+```
+Record 1: skip 4 bytes ("The "), replace 5 bytes ("quikc") with "quick"
+  skip_count   = 0x0004
+  write_length = 0x05
+  write_data   = 717569636b ("quick")
+
+Terminator:
+  skip_count   = 0xFFFF
+  write_length = 0x00
+```
+
+**Patch payload** (hex):
+```
+0004 05 717569636b FFFF 00
+```
+Total: **11 bytes**
+
+**Output 1**:
+```
+6a 4c 0b 00040571756963 6bffff00
+```
+
+**Reconstructed Comment**: `"The quick brown fox jumps over the lazy dog."`
+
+---
+
+### Example 3: Multi-Region Edit (Two Replacements)
+
+**Scenario**: Original comment is `"Alice is a bad developer and writes bad code."` (46 bytes). Author wishes to replace both `"bad"` occurrences: first at byte 10 (replacing "bad developer" → "skilled engineer", 13 chars replacing 13) and second at byte 37 ("bad code" → "clean code").
+
+**RLSW Patch Construction**:
+
+```
+Record 1: skip 10 ("Alice is a"), replace 3 ("bad") with "skilled" (7 bytes)
+  0x000A 07 736b696c6c6564
+
+Record 2: skip 24 (remaining unchanged region " developer and writes "),
+          replace 3 ("bad") with "clean" (5 bytes)
+  0x0018 05 636c65616e
+
+Terminator:
+  FFFF 00
+```
+
+**Patch payload** (hex):
+```
+000a 07 736b696c6c6564 0018 05 636c65616e ffff 00
+```
+Total: 3+7 + 3+5 + 3 = **21 bytes**
+
+**Reconstructed Comment**: `"Alice is a skilled developer and writes clean code."`
+
+---
+
+### Example 4: Chained RNKE (Edit of an Edit)
+
+**Scenario**: After Example 1, the author decides to also fix the second `"bad"` in the already-edited comment `"This project is great and you should feel bad."`. The `source_txid` now references the prior RNKE transaction, and `source_crc32` is computed over `"This project is great and you should feel bad."` (46 bytes).
+
+The patch targets byte 41 (`"bad"` → `"good"`):
+
+```
+Record 1: skip 41, replace 3 ("bad") with "good" (4 bytes)
+  0x0029 04 676f6f64
+
+Terminator:
+  FFFF 00
+```
+
+**Patch payload** (hex):
+```
+0029 04 676f6f64 ffff 00
+```
+Total: **10 bytes**
+
+**Reconstructed Comment**: `"This project is great and you should feel good."`
+
+## Processing Rules
+
+### Indexing
+
+The rank-backend-ts indexer processes RNKE transactions according to these rules:
+
+1. **Transaction Discovery**: Scan all transactions for OP\_RETURN outputs with RNKE LOKAD prefix in Output 0
+2. **LOKAD Validation**: Verify LOKAD prefix is `0x524e4b45` in Output 0
+3. **Output Validation**: Verify minimum 2 and maximum 3 OP\_RETURN outputs
+4. **Metadata Extraction**: Parse platform, profile ID, source TXID, and source CRC32 from Output 0
+5. **Source Resolution**: Retrieve the source comment bytes from the indexed RNKC (or prior RNKE) transaction identified by `source_txid`
+6. **CRC32 Verification**: Compute CRC-32/ISO-HDLC over the source comment bytes and compare against `source_crc32`; reject if mismatch
+7. **Authorship Verification**: Confirm that at least one RNKE input address matches at least one input address of the root RNKC transaction
+8. **Patch Extraction**: Concatenate patch data from Outputs 1 and 2
+9. **Patch Application**: Apply the RLSW patch per the reconstruction algorithm
+10. **Output Validation**: Validate that the reconstructed comment is well-formed UTF-8 and within length bounds
+11. **Fee Validation**: Verify that total satoshis burned meets the minimum fee rate against patch payload length
+12. **Canonicalization**: If a more recent valid RNKE already exists for the same source RNKC `txid`, mark this transaction as superseded; otherwise, store as the current canonical edit
+13. **Database Storage**: Store validated and reconstructed comment text in the database
+
+### Comment Canonicalization
+
+When multiple RNKE transactions reference the same root RNKC `txid` (directly or through a chain), the following precedence rules apply:
+
+1. The RNKE transaction confirmed at the **greater block height** takes precedence.
+2. If two RNKE transactions are confirmed in the same block, the one with the **lower transaction index** within the block takes precedence.
+3. Superseded RNKE transactions are retained in the database for audit purposes but are not used for comment display.
+
+Indexers must maintain the full edit history for each RNKC `txid`, including all superseded RNKE transactions, to support audit trails and chain reorganization handling.
+
+### Chained Edit Resolution
+
+When an RNKE's `source_txid` references a prior RNKE (rather than the root RNKC), the indexer must resolve the chain recursively:
+
+1. Identify the `source_txid` of the RNKE being processed.
+2. If `source_txid` is an RNKE transaction, retrieve its resolved output text.
+3. Apply the current RNKE's patch to that resolved text.
+4. Repeat until the chain is fully resolved.
+
+Circular references (RNKE A → RNKE B → RNKE A) are invalid and must be detected and rejected. Indexers must enforce a maximum chain depth of **16** edits; RNKE transactions that would exceed this depth are rejected.
+
+### Mempool Handling
+
+- **Unconfirmed RNKE Transactions**: Cached in memory with timestamp, pending confirmation
+- **Dependency Ordering**: An RNKE in the mempool whose `source_txid` has not yet been confirmed is held pending until the source is confirmed or the RNKE transaction is evicted
+- **Confirmation**: Moved to persistent storage when included in a block
+- **Reorg Handling**: On block disconnection, affected RNKE transactions are reverted; the prior canonical edit (or original RNKC comment) is restored
+
+### State Management
+
+The indexer maintains:
+
+- **Edit History**: Full RNKE transaction history per RNKC `txid` for audit trails
+- **Canonical Edit**: The current winning RNKE (or lack thereof) for each RNKC `txid`
+- **Resolved Comment**: The fully reconstructed current comment text for display
+- **Chain Map**: A mapping of RNKE `txid` → `source_txid` for chain traversal and cycle detection
+
+## Constraints and Limitations
+
+### Size Limitations
+
+- **Maximum Patch Payload Length**: 440 bytes (220 bytes × 2 outputs)
+- **Maximum Reconstructed Comment Length**: 440 bytes (inherited from RNKC)
+- **Maximum Output Count**: 3 OP\_RETURN outputs
+- **OP\_PUSHDATA1 Limit**: 255 bytes per output (minus overhead = 220 bytes max data)
+- **Minimum Patch Payload Length**: 3 bytes (one minimal RLSW record)
+
+### Encoding Limitations
+
+- **Patch Payload**: Raw binary (RLSW-encoded); not required to be valid UTF-8 itself
+- **Reconstructed Comment**: Must be valid UTF-8 after patch application
+- **`write_data` Fields**: Must each be individually valid UTF-8 sequences (to ensure valid UTF-8 output when concatenated with surrounding source bytes)
+- **Source TXID**: 32 bytes, little-endian internal byte order
+- **Source CRC32**: 4 bytes, big-endian
+
+### Operational Limitations
+
+- **Authorship Only**: Only the original RNKC author (as determined by input address matching) may broadcast a valid RNKE against that RNKC transaction
+- **Maximum Chain Depth**: 16 chained RNKE transactions per root RNKC `txid`
+- **No Platform Change**: Platform and profile ID cannot be altered via RNKE
+- **No Post ID Change**: The post ID association from the original RNKC transaction cannot be altered via RNKE
+- **Confirmed Source Required**: The source transaction must be confirmed before an RNKE against it will be processed (mempool-to-mempool chaining is not supported)
+
+## Integration with Other Protocols
+
+### Relationship with RNKC
+
+RNKE is strictly additive to RNKC. An RNKC transaction's on-chain data is never modified; RNKE only affects the **indexer's resolved view** of a comment. Applications that do not implement RNKE will continue to display the original RNKC comment text unmodified.
+
+### Coexistence with Other LOKAD Protocols
+
+Because RNKE consumes 2–3 OP\_RETURN outputs, it is not advisable to combine RNKE with other LOKAD protocols in the same transaction, consistent with the same guidance in the RNKC specification.
+
+### Display Recommendations
+
+Applications implementing RNKE support should:
+
+- Display the resolved (post-edit) comment text as the primary content
+- Indicate to the user that the comment has been edited (e.g., with an "edited" label)
+- Optionally provide access to the full edit history, including the original RNKC text and each intermediate RNKE revision, for transparency
+
+## References
+
+- [RNKC Protocol Specification](https://github.com/LotusiaStewardship/rank-backend-ts/blob/master/docs/spec/RNKC.md)
+- [LOKAD Prefix Guideline](https://lotusia.org/docs/specs/bitcoin-cash/op_return-prefix-guideline)
+- [Bitcoin Cash OP\_RETURN Specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_return.md)
+- [RANK Protocol Specification](https://github.com/LotusiaStewardship/rank-backend-ts/blob/master/docs/spec/RANK.md)
+- [CRC-32/ISO-HDLC (zlib CRC32)](https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-32-iso-hdlc)
+- [Proof-of-Burn Concept](https://en.wikipedia.org/wiki/Proof_of_burn)
+
+## Version History
+
+- **v1** (Current): Initial RNKE protocol specification
+  - RLSW patch encoding for incremental comment edits
+  - CRC32 source integrity verification
+  - Authorship validation via input address matching
+  - Chained edit support (RNKE referencing prior RNKE)
+  - Maximum chain depth of 16
+  - Fee rate based on patch payload length
+
+## Future Considerations
+
+- **v2**: Potential enhancements (reserved, not yet implemented)
+  - Extended platform support (inheriting from RNKC v2)
+  - Explicit deletion records in RLSW to simplify pure-deletion encoding
+  - Delegated edit authorization (third-party editor whitelisting)
+  - Patch compression for large edits approaching the 440-byte ceiling

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,6 +9,7 @@ import express, {
   NextFunction,
   json,
 } from 'express'
+import { rateLimit } from 'express-rate-limit'
 import { Address, BufferUtil, Message, Networks } from 'xpi-ts/lib/bitcore'
 import {
   PlatformConfiguration,
@@ -41,6 +42,7 @@ import {
 } from '../util/constants'
 import {
   sendJSON,
+  sendRateLimitExceededJSON,
   sendAuthChallenge,
   toLogEntries,
   recomputeInstanceId,
@@ -609,6 +611,21 @@ export class API extends EventEmitter {
     this.app = express()
     this.app.use(json())
     this.app.use('/api/v1', this.router)
+
+    // Add API rate limiting config
+    this.app.use(
+      rateLimit({
+        windowMs: config.api.rateLimitWindowMinutes * 60 * 1000,
+        limit: config.api.rateLimitMaxRequests, // `max` was renamed to `limit` in express-rate-limit v7
+        standardHeaders: true,
+        legacyHeaders: false,
+        skip: () => {
+          // return "false" to NOT skip rate limiting quota for each client
+          return false
+        },
+        handler: sendRateLimitExceededJSON,
+      }),
+    )
   }
 
   /**

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -43,14 +43,20 @@ import {
   sendJSON,
   sendAuthChallenge,
   toLogEntries,
-  isValidInstanceId,
+  recomputeInstanceId,
   log,
-  Validate,
   type LogEntry,
 } from '../util/functions'
 import type { AuthorizationCache } from './api/authCache'
 import type { FeedFilterParams, Timespan } from './database'
 import { Temporal } from './temporal'
+import {
+  validateAdminSecret,
+  validateInstanceId,
+  validateReferralCode,
+  validateScriptPayload,
+  validateSearchType,
+} from '../util/validators'
 
 /**
  * Represents a profile's ranking information including total and change metrics
@@ -343,7 +349,7 @@ const Parameters: Record<EndpointParameter, EndpointParameterHandler> = {
     next: NextFunction,
     searchType: string,
   ) => {
-    const validated = Validate.searchType(searchType as 'profile' | 'post')
+    const validated = validateSearchType(searchType as 'profile' | 'post')
     if (validated.error) {
       return sendJSON(res, { error: validated.error }, validated.statusCode)
     }
@@ -362,7 +368,7 @@ const Parameters: Record<EndpointParameter, EndpointParameterHandler> = {
     next: NextFunction,
     scriptPayload: string | undefined,
   ) => {
-    const result = Validate.scriptPayload(scriptPayload)
+    const result = validateScriptPayload(scriptPayload)
     if (!result.scriptPayload) {
       return sendJSON(
         res,
@@ -457,7 +463,7 @@ const Parameters: Record<EndpointParameter, EndpointParameterHandler> = {
     next: NextFunction,
     instanceId: string | undefined,
   ) => {
-    const result = Validate.instanceId(instanceId)
+    const result = validateInstanceId(instanceId)
     if (result.error) {
       return sendJSON(res, { ...result }, result.statusCode)
     }
@@ -1035,7 +1041,7 @@ export class API extends EventEmitter {
       // REQUEST IS NOW AUTHORIZED
 
       // validate the scriptPayload GET parameter
-      const validationResult = Validate.scriptPayload(req.params.scriptPayload)
+      const validationResult = validateScriptPayload(req.params.scriptPayload)
       if (validationResult.error) {
         const t1 = (performance.now() - t0).toFixed(3)
         entries.push(['elapsed', `${t1}ms`])
@@ -1467,19 +1473,19 @@ export class API extends EventEmitter {
           error?: string
           statusCode?: number
         }
-        validated = Validate.instanceId(body.instanceId)
+        validated = validateInstanceId(body.instanceId)
         if (!validated.instanceId) {
           throw new Error(validated.error)
         }
-        validated = Validate.scriptPayload(body.scriptPayload)
+        validated = validateScriptPayload(body.scriptPayload)
         if (!validated.scriptPayload) {
           throw new Error('scriptPayload must be specified')
         }
         if (!Date.parse(body.createdAt)) {
           throw new Error(`createdAt date format is invalid`)
         }
-        // validate instanceId matches input and meets/exceeds difficulty
-        if (!(await isValidInstanceId(body))) {
+        // recompute instanceId to match input body and diff check
+        if (!(await recomputeInstanceId(body))) {
           throw new Error(`instanceId does not match input data`)
         }
         // verify message signature
@@ -1557,7 +1563,7 @@ export class API extends EventEmitter {
           signature: string
         }
         // Validate scriptPayload
-        const validated = Validate.scriptPayload(body.scriptPayload)
+        const validated = validateScriptPayload(body.scriptPayload)
         if (!validated.scriptPayload) {
           return sendJSON(res, { error: validated.error }, validated.statusCode)
         }
@@ -1670,7 +1676,7 @@ export class API extends EventEmitter {
           signature: string
         }
         // Validate referral code format
-        const validatedCode = Validate.referralCode(body.code)
+        const validatedCode = validateReferralCode(body.code)
         if (!validatedCode.code) {
           return sendJSON(
             res,
@@ -1679,7 +1685,7 @@ export class API extends EventEmitter {
           )
         }
         // Validate scriptPayload
-        const validated = Validate.scriptPayload(body.scriptPayload)
+        const validated = validateScriptPayload(body.scriptPayload)
         if (!validated.scriptPayload) {
           return sendJSON(res, { error: validated.error }, validated.statusCode)
         }
@@ -1846,7 +1852,7 @@ export class API extends EventEmitter {
       try {
         // Validate admin secret
         const adminHeader = req.headers['x-admin-secret'] as string | undefined
-        const adminValidated = Validate.adminSecret(
+        const adminValidated = validateAdminSecret(
           adminHeader,
           config.admin.secret,
         )

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -19,12 +19,7 @@ import {
 } from 'xpi-ts/lib/rank'
 import type { RuntimeState } from './state'
 import { Database } from './database'
-import {
-  computeFullEngagement,
-  getTierName,
-  getTierBonus,
-  computeStreakBonus,
-} from './engagement'
+import { getTierName, getTierBonus, computeStreakBonus } from './engagement'
 import config from '../config'
 import {
   API_SERVER_PORT,
@@ -177,12 +172,12 @@ export type ChartType = 'wallet'
 export type ChartDataType = 'summary' | 'activity'
 
 /** Mapping of stats route paths to their corresponding database method names */
-export enum StatsRoutes {
-  'profiles/top-ranked' = 'getStatsPlatformRanked',
-  'profiles/lowest-ranked' = 'getStatsPlatformRanked',
-  'posts/top-ranked' = 'getStatsPlatformRanked',
-  'posts/lowest-ranked' = 'getStatsPlatformRanked',
-}
+export const StatsRoutes = {
+  'profiles/top-ranked': 'getStatsPlatformRanked',
+  'profiles/lowest-ranked': 'getStatsPlatformRanked',
+  'posts/top-ranked': 'getStatsPlatformRanked',
+  'posts/lowest-ranked': 'getStatsPlatformRanked',
+} as const
 /** Valid stats route path strings */
 export type StatsRoute = keyof typeof StatsRoutes
 
@@ -372,13 +367,11 @@ const Parameters: Record<EndpointParameter, EndpointParameterHandler> = {
   ) => {
     const result = validateScriptPayload(scriptPayload)
     if (!result.scriptPayload) {
-      return sendJSON(
-        res,
-        { error: `invalid script payload specified` },
-        HTTP.BAD_REQUEST,
-      )
+      return sendJSON(res, { error: result.error }, result.statusCode)
     }
     // TODO: handle signature validation here
+
+    // scriptPayload is validated so add to req params
     req.params.scriptPayload = result.scriptPayload
     next()
   },
@@ -539,7 +532,6 @@ export class API extends EventEmitter {
     this.state = state
     this.db = db
     this.temporal = temporal
-    //this.app = express()
     this.authCache = authCache
     this.router = Router({
       caseSensitive: false,
@@ -547,7 +539,9 @@ export class API extends EventEmitter {
       strict: true,
     })
 
+    // ============================================================
     // Router parameter configuration
+    // ============================================================
     this.router.param('platform', Parameters.platform)
     this.router.param('profileId', Parameters.profileId)
     this.router.param('postId', Parameters.postId)
@@ -560,11 +554,15 @@ export class API extends EventEmitter {
     this.router.param('searchType', Parameters.searchType)
     this.router.param('txid', Parameters.txid)
 
+    // ============================================================
     // Router GET endpoint configuration (DEEPEST ROUTES FIRST!)
+    // ============================================================
     this.router.get(
       '/wallet/summary/:instanceId/:scriptPayload/:startTime?/:endTime?',
       this.GET.wallet,
     )
+    // Router GET endpoint configuration (engagement)
+    this.router.get('/wallet/engagement/:scriptPayload', this.GET.engagement!)
     this.router.get(
       '/wallet/:instanceId/:scriptPayload/:startTime?/:endTime?',
       this.GET.wallet,
@@ -573,18 +571,18 @@ export class API extends EventEmitter {
       '/feed/trending/:windowHours?/:limit?',
       this.GET.feedTrending,
     )
-    this.router.get('/feed/posts', this.GET.feedPosts)
-    this.router.get('/feed/leaderboard/:period/:limit?', this.GET.leaderboard)
-    this.router.get('/votes/:page?/:pageSize?', this.GET.voteActivity)
+    this.router.get('/feed/posts', this.GET.feedPosts!)
+    this.router.get('/feed/leaderboard/:period/:limit?', this.GET.leaderboard!)
+    this.router.get('/votes/:page?/:pageSize?', this.GET.voteActivity!)
     this.router.get('/txs/:platform/:profileId/:page?/:pageSize?', this.GET.txs)
-    this.router.get('/charts/:chartType/:dataType/:timespan?', this.GET.charts)
-    this.router.get('/profiles/:page?/:pageSize?', this.GET.profiles)
-    this.router.get('/search/:searchType/:query', this.GET.search)
+    this.router.get('/charts/:chartType/:dataType/:timespan?', this.GET.charts!)
+    this.router.get('/profiles/:page?/:pageSize?', this.GET.profiles!)
+    this.router.get('/search/:searchType/:query', this.GET.search!)
     this.router.get(
       '/stats/:statsRoute(profiles/[a-z-]+|posts/[a-z-]+)/:timespan?/:votes?/:pageNum?',
       this.GET.stats,
     )
-    this.router.get('/:platform/:profileId/:postId', this.GET.post)
+    this.router.get('/:platform/:profileId/:postId', this.GET.post!)
     this.router.get(
       '/:platform/:profileId/posts/:page?/:pageSize?',
       this.GET.profilePosts,
@@ -592,20 +590,21 @@ export class API extends EventEmitter {
     this.router.get('/:platform/:profileId/:postId', this.GET.post)
     this.router.get('/:platform/:profileId', this.GET.profile) // accepts `scriptPayload` query param
 
-    // Router GET endpoint configuration (engagement)
-    this.router.get('/wallet/engagement/:scriptPayload', this.GET.engagement)
-
+    // ============================================================
     // Router POST endpoint configuration (DEEPEST ROUTES FIRST!)
-    this.router.post('/admin/referral/genesis', this.POST.referralGenesis)
-    this.router.post('/referral/generate', this.POST.referralGenerate)
-    this.router.post('/referral/redeem', this.POST.referralRedeem)
+    // ============================================================
+    this.router.post('/admin/referral/genesis', this.POST.referralGenesis!)
+    this.router.post('/referral/generate', this.POST.referralGenerate!)
+    this.router.post('/referral/redeem', this.POST.referralRedeem!)
     // Router POST endpoint for retrieving multiple posts by platform.
     // Used by the extension when a user is scrolling their feed
     // and needs to load their vote history for all posts in the feed
-    this.router.post('/posts/:platform/:scriptPayload', this.POST.posts)
+    this.router.post('/posts/:platform/:scriptPayload', this.POST.posts!)
 
+    // ============================================================
     // Router PATCH endpoint configuration (DEEPEST ROUTES FIRST!)
-    //this.router.patch('/:platform/:profileId/:postId', this.PATCH.post)
+    // ============================================================
+    //this.router.patch('/:platform/:profileId/:postId', this.PATCH.post!)
 
     // App/Server setup
     this.app = express()
@@ -1035,6 +1034,7 @@ export class API extends EventEmitter {
         ...toLogEntries(req.params),
       ] as LogEntry[]
 
+      // Get Authorization header to process authorization
       const authorizationHeader = req.headers['authorization']
       if (!authorizationHeader) {
         const t1 = (performance.now() - t0).toFixed(3)
@@ -1289,61 +1289,61 @@ export class API extends EventEmitter {
     },
 
     /**
-     * Retrieves engagement profile for a wallet
+     * Retrieves engagement profile for a wallet from pre-computed WalletEngagement table.
+     * Data is updated incrementally during indexing (nngMempoolTxAdd).
      * @param req Express Request object containing `scriptPayload` parameter
      * @param res Express Response object to send back engagement data
      * @returns JSON response with engagement data or error message
      */
     engagement: async (req: Request, res: Response) => {
       const t0 = performance.now()
+      const entries = [
+        ['api', 'get.engagement'],
+        ['action', 'engagement'],
+        [
+          'src',
+          (req.headers['x-forwarded-for'] as string) ??
+            req.socket.remoteAddress,
+        ],
+        ...toLogEntries(req.params),
+      ] as LogEntry[]
+
+      // gather and validate query params
       const { scriptPayload } = req.params
-      const validated = Validate.scriptPayload(scriptPayload)
+      const validated = validateScriptPayload(scriptPayload)
+
       if (!validated.scriptPayload) {
         return sendJSON(res, { error: validated.error }, validated.statusCode)
       }
+
       try {
-        // Compute the full engagement profile (gathers all metrics from DB)
-        const engagement = await computeFullEngagement(
-          this.db,
+        // Read pre-computed engagement data (single DB query)
+        const record = await this.db.getOrCreateWalletEngagement(
           validated.scriptPayload,
-        )
-        // Persist the computed engagement data
-        const record = await this.db.upsertWalletEngagement(
-          validated.scriptPayload,
-          {
-            ...engagement,
-            lifetimeRewards:
-              (
-                await this.db.getOrCreateWalletEngagement(
-                  validated.scriptPayload,
-                )
-              ).lifetimeRewards ?? 0n,
-          },
         )
         const t1 = (performance.now() - t0).toFixed(3)
-        log([
-          ['api', 'get.engagement'],
-          ['scriptPayload', validated.scriptPayload],
-          ['tier', `${engagement.tier}`],
-          ['ep', `${engagement.engagementPoints}`],
+        entries.push(
+          ['tier', `${record.tier}`],
+          ['ep', `${record.engagementPoints}`],
           ['elapsed', `${t1}ms`],
-        ])
+        )
+        log(entries)
         return sendJSON(
           res,
           {
             scriptPayload: validated.scriptPayload,
-            tier: engagement.tier,
-            tierName: getTierName(engagement.tier),
-            tierBonus: getTierBonus(engagement.tier),
-            engagementPoints: engagement.engagementPoints,
-            epBreakdown: engagement.epBreakdown,
-            streakBonus: computeStreakBonus(engagement.currentStreak),
-            lifetimeVotes: engagement.lifetimeVotes,
-            lifetimeReferrals: engagement.lifetimeReferrals,
-            lifetimeComments: engagement.lifetimeComments,
-            currentStreak: engagement.currentStreak,
-            longestStreak: engagement.longestStreak,
-            lastVoteDate: engagement.lastVoteDate?.toISOString() ?? null,
+            tier: record.tier,
+            tierName: getTierName(record.tier),
+            tierBonus: getTierBonus(record.tier),
+            engagementPoints: record.engagementPoints,
+            epBreakdown: record.epBreakdown,
+            streakBonus: computeStreakBonus(record.currentStreak),
+            lifetimeVotes: record.lifetimeVotes,
+            lifetimeReferrals: record.lifetimeReferrals,
+            lifetimeComments: record.lifetimeComments,
+            currentStreak: record.currentStreak,
+            longestStreak: record.longestStreak,
+            lastVoteDate: record.lastVoteDate?.toISOString() ?? null,
             lifetimeRewards: record.lifetimeRewards.toString(),
             updatedAt: record.updatedAt.toISOString(),
           },

--- a/lib/api/authCache.ts
+++ b/lib/api/authCache.ts
@@ -1,5 +1,6 @@
-import { log, processAuthorizationHeader, Validate } from '../../util/functions'
+import { log, processAuthorizationHeader } from '../../util/functions'
 import { API_AUTH_CACHE_ENTRY_TTL } from '../../util/constants'
+import { validateSignature } from '../../util/validators'
 import type { RuntimeState } from '../state'
 
 /**
@@ -202,6 +203,6 @@ export class AuthorizationCache {
     data: string
     signature: string
   }): boolean {
-    return !!Validate.signature(payload).signature
+    return !!validateSignature(payload).signature
   }
 }

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -227,6 +227,10 @@ type TargetEntityMetricsAPI = {
   votesPositive: number
   votesNegative: number
 }
+/**
+ * Valid time period values for filtering and aggregating data.
+ * Used throughout the API for date range queries.
+ */
 export type Timespan =
   | 'now'
   | 'today'
@@ -235,6 +239,11 @@ export type Timespan =
   | 'month'
   | 'quarter'
   | 'all'
+
+/**
+ * Prisma select object for retrieving entity ranking metrics.
+ * Used to consistently fetch ranking-related fields across queries.
+ */
 const targetEntityMetricsSelect = {
   ranking: true,
   satsPositive: true,

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -289,6 +289,18 @@ export const getTimestampUTC = (timespan: Timespan = 'month'): number => {
   }
 }
 
+/**
+ * Database class that provides a unified interface for all database operations.
+ * Handles RANK and RNKC transaction storage, block management, entity metrics,
+ * referral codes, wallet engagement tracking, and API query methods.
+ *
+ * @example
+ * ```typescript
+ * const db = new Database(process.env.DATABASE_URL)
+ * await db.connect()
+ * const checkpoint = await db.getCheckpoint()
+ * ```
+ */
 export class Database {
   private db: PrismaClient
 

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2467,6 +2467,8 @@ export class Database {
       currentStreak: number
       longestStreak: number
       lastVoteDate: Date | null
+      totalBurnedSats?: bigint
+      firstVoteDate?: Date | null
       lifetimeRewards: bigint
     },
   ) {

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1953,7 +1953,8 @@ export class Database {
                 id: postId,
                 platform: postPlatform,
                 profileId,
-                data, // data is the comment text for Lotusia posts
+                // NOTE: Latest Prisma 6.19 changed Uint8Array type constraints, so we cast it here
+                data: data as Uint8Array<ArrayBuffer>, // data is the comment text for Lotusia posts
                 firstVoted: postTimestamp,
                 lastVoted: postLastVoted,
                 ranking: postRanking,
@@ -1968,7 +1969,10 @@ export class Database {
               // satisfying the RankComment FK constraint [txid, scriptPayload, data]
               update: {
                 ...postIncrements,
-                ...(data !== undefined && { data }),
+                ...(data !== undefined && {
+                  // NOTE: Latest Prisma 6.19 changed Uint8Array type constraints, so we cast it here
+                  data: data as Uint8Array<ArrayBuffer>,
+                }),
                 lastVoted: postLastVoted,
               },
             }),

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -42,6 +42,7 @@ import type {
 } from 'xpi-ts/lib/rank'
 import { toAsyncIterable } from '../util/functions'
 import { BufferUtil } from 'xpi-ts/lib/bitcore'
+import { computeEPBreakdown, computeTierFromEP } from './engagement'
 
 export type IndexedTransactionRANK = IndexedTransaction & PrismaRANK
 export type IndexedTransactionRNKC = IndexedTransaction &
@@ -2477,6 +2478,152 @@ export class Database {
       })
     } catch (e) {
       throw new Error(`db.upsertWalletEngagement: ${e.message}`)
+    }
+  }
+
+  /**
+   * Incrementally updates a WalletEngagement record when a new RANK vote is indexed.
+   * Performs 1 read + pure math + 1 write instead of 8 aggregate queries.
+   *
+   * @param scriptPayload - The voter's scriptPayload
+   * @param satsBurned - The sats burned in this RANK transaction
+   * @param voteCount - Number of RANK outputs in this transaction for this voter (usually 1)
+   */
+  async incrementWalletEngagementForVote(
+    scriptPayload: string,
+    satsBurned: bigint,
+    voteCount: number = 1,
+  ) {
+    try {
+      // 1. Read existing record (or create with defaults)
+      const existing = await this.db.walletEngagement.upsert({
+        where: { scriptPayload },
+        create: { scriptPayload },
+        update: {},
+      })
+
+      // 2. Increment counters
+      const lifetimeVotes = existing.lifetimeVotes + voteCount
+      const totalBurnedSats = existing.totalBurnedSats + satsBurned
+      const now = new Date()
+      now.setUTCHours(0, 0, 0, 0)
+      const firstVoteDate = existing.firstVoteDate ?? now
+
+      // 3. Compute streak from lastVoteDate vs today (pure date math)
+      let currentStreak = existing.currentStreak
+      if (existing.lastVoteDate) {
+        const lastVote = new Date(existing.lastVoteDate)
+        lastVote.setUTCHours(0, 0, 0, 0)
+        const diffDays = Math.floor(
+          (now.getTime() - lastVote.getTime()) / 86_400_000,
+        )
+        if (diffDays === 0) {
+          // Same day — streak unchanged
+        } else if (diffDays === 1) {
+          // Consecutive day — extend streak
+          currentStreak += 1
+        } else {
+          // Gap > 1 day — streak resets to 1 (today counts)
+          currentStreak = 1
+        }
+      } else {
+        // First ever vote
+        currentStreak = 1
+      }
+      const longestStreak = Math.max(currentStreak, existing.longestStreak)
+
+      // 4. Compute account age from firstVoteDate
+      const diffMs = now.getTime() - firstVoteDate.getTime()
+      const accountAgeMonths = Math.floor(diffMs / (30.44 * 86_400_000))
+
+      // 5. Recompute EP from stored counters (pure math, 0 DB queries)
+      const epBreakdown = computeEPBreakdown(
+        lifetimeVotes,
+        existing.lifetimeReferrals,
+        existing.lifetimeComments,
+        totalBurnedSats,
+        currentStreak,
+        accountAgeMonths,
+      )
+      const tier = computeTierFromEP(epBreakdown.total)
+
+      // 6. Write back
+      return await this.db.walletEngagement.update({
+        where: { scriptPayload },
+        data: {
+          tier,
+          engagementPoints: epBreakdown.total,
+          epBreakdown,
+          lifetimeVotes,
+          totalBurnedSats,
+          firstVoteDate,
+          currentStreak,
+          longestStreak,
+          lastVoteDate: new Date(),
+        },
+      })
+    } catch (e) {
+      throw new Error(`db.incrementWalletEngagementForVote: ${e.message}`)
+    }
+  }
+
+  /**
+   * Incrementally updates a WalletEngagement record when a new RNKC comment is indexed.
+   * Performs 1 read + pure math + 1 write instead of 8 aggregate queries.
+   *
+   * @param scriptPayload - The commenter's scriptPayload
+   * @param satsBurned - The sats burned in this RNKC transaction
+   */
+  async incrementWalletEngagementForComment(
+    scriptPayload: string,
+    satsBurned: bigint,
+  ) {
+    try {
+      // 1. Read existing record (or create with defaults)
+      const existing = await this.db.walletEngagement.upsert({
+        where: { scriptPayload },
+        create: { scriptPayload },
+        update: {},
+      })
+
+      // 2. Increment counters
+      const lifetimeComments = existing.lifetimeComments + 1
+      const totalBurnedSats = existing.totalBurnedSats + satsBurned
+
+      // 3. Compute account age from firstVoteDate (comments don't affect streak or firstVoteDate)
+      const now = new Date()
+      now.setUTCHours(0, 0, 0, 0)
+      const accountAgeMonths = existing.firstVoteDate
+        ? Math.floor(
+            (now.getTime() - existing.firstVoteDate.getTime()) /
+              (30.44 * 86_400_000),
+          )
+        : 0
+
+      // 4. Recompute EP from stored counters (pure math, 0 DB queries)
+      const epBreakdown = computeEPBreakdown(
+        existing.lifetimeVotes,
+        existing.lifetimeReferrals,
+        lifetimeComments,
+        totalBurnedSats,
+        existing.currentStreak,
+        accountAgeMonths,
+      )
+      const tier = computeTierFromEP(epBreakdown.total)
+
+      // 5. Write back
+      return await this.db.walletEngagement.update({
+        where: { scriptPayload },
+        data: {
+          tier,
+          engagementPoints: epBreakdown.total,
+          epBreakdown,
+          lifetimeComments,
+          totalBurnedSats,
+        },
+      })
+    } catch (e) {
+      throw new Error(`db.incrementWalletEngagementForComment: ${e.message}`)
     }
   }
 

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2967,7 +2967,38 @@ export class Database {
 
         const totalPages = Math.ceil(totalItems / normalizedPageSize)
 
-        // Convert each post to PostAPI shape, computing R62/R65 signals
+        // R66: compute velocity-window burns for candidate posts (curated + controversial).
+        // This detects flash-attack spikes within the short detection window vs baseline.
+        const velocityWindowSeconds = FEED_RANKING_VELOCITY_WINDOW_HOURS * 3600
+        const velocityWindowStart =
+          Math.floor(Date.now() / 1000) - velocityWindowSeconds
+        const velocityGroups = await tx.rankTransaction.groupBy({
+          by: ['platform', 'profileId', 'postId'],
+          where: {
+            timestamp: { gte: velocityWindowStart },
+            postId: { not: null },
+          },
+          _sum: { sats: true },
+        })
+        const velocityMap = new Map<string, bigint>()
+        for (const vg of velocityGroups) {
+          if (vg.postId) {
+            velocityMap.set(
+              `${vg.platform}:${vg.profileId}:${vg.postId}`,
+              vg._sum.sats ?? 0n,
+            )
+          }
+        }
+        // Compute rolling median of window burns across all candidates for R66 baseline.
+        const allWindowBurns = [...velocityMap.values()]
+          .map(v => Number(v))
+          .sort((a, b) => a - b)
+        const medianWindowBurns =
+          allWindowBurns.length > 0
+            ? allWindowBurns[Math.floor(allWindowBurns.length / 2)]
+            : 1
+
+        // Convert each post to PostAPI shape, computing R62/R65/R66 signals
         const feedPosts: PostAPI[] = []
         for (const post of posts) {
           // R64: decay anchor depends on sort mode.
@@ -2977,11 +3008,20 @@ export class Database {
           //   surfaces correctly.
           const decayAnchor = Number(post.firstVoted)
 
+          // R66: compute velocity dampening for this post
+          const velocityKey = `${post.platform}:${post.profileId}:${post.id}`
+          const velocityBurns = velocityMap.get(velocityKey) ?? 0n
+          const velocityDampening = computeVelocityDampening(
+            velocityBurns,
+            BigInt(Math.floor(medianWindowBurns)),
+          )
+
           // R62/R63/R64/R66: compute composite feed score for this post
           const signals = computeCompositeFeedScore(
             post.satsPositive,
             post.satsNegative,
             decayAnchor,
+            velocityDampening,
           )
 
           // Build PostAPI object with computed signals

--- a/lib/database.ts
+++ b/lib/database.ts
@@ -2841,6 +2841,7 @@ export class Database {
     try {
       return await this.db.$transaction(async tx => {
         // Build where clause for Post model
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const whereClause: any = {}
         if (platform) {
           whereClause.platform = platform
@@ -2870,6 +2871,7 @@ export class Database {
         // Build orderBy based on sort mode.
         // 'curated' fetches by linear ranking first, then re-sorts in-memory
         // after applying R62–R65 dampening (Prisma cannot order by relation fields).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let orderBy: any
         switch (sortBy) {
           case 'recent':

--- a/lib/engagement.ts
+++ b/lib/engagement.ts
@@ -311,6 +311,8 @@ export async function computeFullEngagement(
   currentStreak: number
   longestStreak: number
   lastVoteDate: Date | null
+  totalBurnedSats: bigint
+  firstVoteDate: Date | null
 }> {
   // Gather all raw metrics in parallel
   const [
@@ -361,6 +363,15 @@ export async function computeFullEngagement(
     ? new Date(Number(latestTimestamp) * 1_000)
     : null
 
+  // Compute first vote date (normalized to UTC midnight) from earliestTimestamp
+  const firstVoteDate = earliestTimestamp
+    ? (() => {
+        const d = new Date(Number(earliestTimestamp) * 1_000)
+        d.setUTCHours(0, 0, 0, 0)
+        return d
+      })()
+    : null
+
   return {
     tier,
     engagementPoints: epBreakdown.total,
@@ -371,5 +382,7 @@ export async function computeFullEngagement(
     currentStreak,
     longestStreak,
     lastVoteDate,
+    totalBurnedSats,
+    firstVoteDate,
   }
 }

--- a/lib/engagement.ts
+++ b/lib/engagement.ts
@@ -1,3 +1,38 @@
+/**
+ * Engagement Points (EP) System
+ *
+ * This module implements the RANK engagement scoring and tier progression system.
+ * It provides functions to compute Engagement Points (EP) from wallet activity metrics,
+ * assign tier levels based on EP thresholds, and calculate bonus multipliers for
+ * streak maintenance and referral rewards.
+ *
+ * The EP formula incorporates multiple signals to create a holistic engagement score:
+ * - Lifetime RANK votes (linear weight)
+ * - Redeemed referrals (high weight to incentivize growth)
+ * - RNKC comments (moderate weight)
+ * - Total XPI burned (sub-linear sqrt scaling to prevent whale dominance)
+ * - Consecutive voting streak (bonus for consistency)
+ * - Account age (capped at 12 months to prevent Sybil advantage)
+ *
+ * Tier progression provides multiplicative bonuses to daily payout rewards:
+ * - Tier 0 (Newcomer): 0-19 EP, +0% bonus
+ * - Tier 1 (Voter): 20-99 EP, +5% bonus
+ * - Tier 2 (Regular): 100-499 EP, +10% bonus
+ * - Tier 3 (Advocate): 500-1999 EP, +15% bonus
+ * - Tier 4 (Champion): 2000-9999 EP, +35% bonus
+ * - Tier 5 (Steward): 10000+ EP, +50% bonus
+ *
+ * Streak bonuses apply on top of tier bonuses for consecutive daily voting:
+ * - 3+ days: +5%
+ * - 7+ days: +10%
+ * - 14+ days: +20%
+ * - 30+ days: +30%
+ * - 60+ days: +50%
+ *
+ * @module engagement
+ * @see {@link https://lotusia.org/docs/rank/engagement RANK Engagement Documentation}
+ */
+
 import type { Database } from './database'
 
 /**
@@ -24,21 +59,21 @@ export const EP_WEIGHTS = {
  * Tiers are assigned based on cumulative EP score.
  *
  * | Tier | Name      | EP Required | Bonus |
- * |------|-----------|------------|-------|
- * | 0    | Newcomer  | 0-19       | +0    |
- * | 1    | Voter     | 20-99      | +0.5  |
- * | 2    | Regular   | 100-499    | +1    |
- * | 3    | Advocate  | 500-1999   | +1.5  |
- * | 4    | Champion  | 2000-9999  | +2    |
- * | 5    | Steward   | 10000+     | +3    |
+ * |------|-----------|-------------|-------|
+ * | 0    | Newcomer  | 0-19        | +0%   |
+ * | 1    | Voter     | 20-99       | +5%   |
+ * | 2    | Regular   | 100-499     | +10%  |
+ * | 3    | Advocate  | 500-1999    | +15%  |
+ * | 4    | Champion  | 2000-9999   | +35%  |
+ * | 5    | Steward   | 10000+      | +50%  |
  */
 export const TIER_THRESHOLDS = [
   { tier: 0, name: 'Newcomer', minEP: 0, bonus: 0 },
-  { tier: 1, name: 'Voter', minEP: 20, bonus: 0.5 },
-  { tier: 2, name: 'Regular', minEP: 100, bonus: 1 },
-  { tier: 3, name: 'Advocate', minEP: 500, bonus: 1.5 },
-  { tier: 4, name: 'Champion', minEP: 2_000, bonus: 2 },
-  { tier: 5, name: 'Steward', minEP: 10_000, bonus: 3 },
+  { tier: 1, name: 'Voter', minEP: 20, bonus: 0.05 },
+  { tier: 2, name: 'Regular', minEP: 100, bonus: 0.1 },
+  { tier: 3, name: 'Advocate', minEP: 500, bonus: 0.15 },
+  { tier: 4, name: 'Champion', minEP: 2_000, bonus: 0.35 },
+  { tier: 5, name: 'Steward', minEP: 10_000, bonus: 0.5 },
 ] as const
 
 /**
@@ -47,11 +82,11 @@ export const TIER_THRESHOLDS = [
  */
 export const STREAK_BONUS_THRESHOLDS = [
   { minDays: 0, bonus: 0 },
-  { minDays: 3, bonus: 0.25 },
-  { minDays: 7, bonus: 0.5 },
-  { minDays: 14, bonus: 1.0 },
-  { minDays: 30, bonus: 1.5 },
-  { minDays: 60, bonus: 2.0 },
+  { minDays: 3, bonus: 0.05 },
+  { minDays: 7, bonus: 0.1 },
+  { minDays: 14, bonus: 0.2 },
+  { minDays: 30, bonus: 0.3 },
+  { minDays: 60, bonus: 0.5 },
 ] as const
 
 /**
@@ -217,9 +252,7 @@ export function computeStreakFromDates(voteDates: string[]): number {
   const firstDateMs = firstDate.getTime()
 
   // If the most recent vote is not today or yesterday, streak is broken
-  const daysSinceLastVote = Math.floor(
-    (todayMs - firstDateMs) / 86_400_000,
-  )
+  const daysSinceLastVote = Math.floor((todayMs - firstDateMs) / 86_400_000)
   if (daysSinceLastVote > 1) return 0
 
   let streak = 1

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -67,8 +67,8 @@ export interface TransactionOutputRANK {
  * Contains comment data and reply target information
  */
 export interface TransactionOutputRNKC {
-  /** The comment data as raw bytes */
-  data: Uint8Array
+  /** The comment data as raw bytes, casted to match Prisma 6.19 interface */
+  data: Uint8Array<ArrayBuffer>
   /** The fee rate for the transaction */
   feeRate: number
   /** The platform of the entity being replied to */
@@ -1085,6 +1085,7 @@ export class Indexer extends EventEmitter {
           sats: BigInt(tx.outputs[0].satoshis),
           timestamp: block?.timestamp, // undefined until block is connected
           ...rnkc,
+          data: rnkc.data as Uint8Array<ArrayBuffer>,
         }
         break
       }

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -735,19 +735,69 @@ export class Indexer extends EventEmitter {
         //  })
         //}
         this.profileQueue.clear()
-        // Check faucet milestones for each distinct voter in this tx
+        // Check faucet milestones and update engagement for each distinct voter
         if (processed.ranks?.length > 0) {
-          const voterPayloads = processed.ranks.map(r => r.scriptPayload)
-          for (const scriptPayload of voterPayloads) {
-            this.checkFaucetMilestone(scriptPayload).catch(e => {
+          // Aggregate sats per voter (a tx may have multiple RANK outputs from the same voter)
+          const voterSats = new Map<string, { sats: bigint; count: number }>()
+          for (const rank of processed.ranks) {
+            const existing = voterSats.get(rank.scriptPayload)
+            if (existing) {
+              existing.sats += rank.sats
+              existing.count += 1
+            } else {
+              voterSats.set(rank.scriptPayload, {
+                sats: rank.sats,
+                count: 1,
+              })
+            }
+          }
+          for (const [scriptPayload, { sats, count }] of voterSats) {
+            // TODO: the checkFaucetMilestone needs to be reworked to NOT query ALL transactions
+            // for a scriptPayload. Milestones should be another indexed field in WalletEngagement model
+            /* try {
+              await this.checkFaucetMilestone(scriptPayload)
+            } catch (e) {
               log([
                 ['nng', 'warn'],
                 ['action', 'checkFaucetMilestone'],
                 ['scriptPayload', scriptPayload],
+                ['message', `"${e.message}"`],
+              ])
+            } */
+
+            // Incrementally update WalletEngagement for this voter
+            try {
+              await this.db.incrementWalletEngagementForVote(
+                scriptPayload,
+                sats,
+                count,
+              )
+            } catch (e) {
+              log([
+                ['nng', 'warn'],
+                ['action', 'incrementEngagement.vote'],
+                ['scriptPayload', scriptPayload],
+                ['message', `"${e.message}"`],
+              ])
+            }
+          }
+        }
+
+        // Update engagement for RNKC comment submitter
+        if (processed.rnkc) {
+          this.db
+            .incrementWalletEngagementForComment(
+              processed.rnkc.scriptPayload,
+              processed.rnkc.sats,
+            )
+            .catch(e => {
+              log([
+                ['nng', 'warn'],
+                ['action', 'incrementEngagement.comment'],
+                ['scriptPayload', processed.rnkc.scriptPayload],
                 ['message', `"${String(e)}"`],
               ])
             })
-          }
         }
         const t1 = (performance.now() - t0).toFixed(3)
         log([

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,52 +9,38 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "6.5.0",
+        "@prisma/client": "6.19.3",
         "@temporalio/activity": "1.11.7",
         "@temporalio/client": "1.11.7",
         "@temporalio/worker": "1.11.7",
         "@temporalio/workflow": "1.11.7",
-        "dotenv": "16.5.0",
+        "dotenv": "16.6.1",
         "dotenv-cli": "8.0.0",
-        "express": "4.21.2",
-        "flatbuffers": "25.2.10",
+        "express": "4.22.1",
+        "express-rate-limit": "8.3.2",
+        "flatbuffers": "25.9.23",
         "lotus-nng-client": "file:submodules/lotus-nng-client",
         "nanomsg": "file:submodules/lotus-nng-client/submodules/nanomsg",
         "web-push": "3.6.7",
-        "xpi-ts": "0.2.21"
+        "xpi-ts": "0.3.1"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "4.17.25",
         "@types/node": "22.13.14",
         "@types/validator": "13.12.3",
         "@types/web-push": "3.6.4",
-        "prettier": "3.5.3",
-        "prisma": "6.5.0",
+        "prettier": "3.8.3",
+        "prisma": "6.19.3",
         "ts-patch": "3.3.0",
-        "typescript": "5.8.2",
-        "typescript-eslint": "8.28.0",
-        "typescript-transform-paths": "3.5.5"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.1",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
+        "typescript": "5.9.3",
+        "typescript-eslint": "8.58.2",
+        "typescript-transform-paths": "3.5.6"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -82,7 +68,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -426,40 +414,10 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@prisma/client": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -479,52 +437,66 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "esbuild": ">=0.12 <1",
-        "esbuild-register": "3.6.0"
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.21.0",
+        "empathic": "2.0.0"
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0",
-        "@prisma/engines-version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
-        "@prisma/fetch-engine": "6.5.0",
-        "@prisma/get-platform": "6.5.0"
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0",
-        "@prisma/engines-version": "6.5.0-73.173f8d54f8d52e692c7e27e72a88314ec7aeff60",
-        "@prisma/get-platform": "6.5.0"
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.3"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.5.0"
+        "@prisma/debug": "6.19.3"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -571,6 +543,13 @@
       "version": "1.1.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.11.21",
       "hasInstallScript": true,
@@ -607,6 +586,92 @@
         }
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.21.tgz",
+      "integrity": "sha512-v6gjw9YFWvKulCw3ZA1dY+LGMafYzJksm1mD4UZFZ9b36CyHFowYVYug1ajYRIRqEvvfIhHUNV660zTLoVFR8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.21.tgz",
+      "integrity": "sha512-CUiTiqKlzskwswrx9Ve5NhNoab30L1/ScOfQwr1duvNlFvarC8fvQSgdtpw2Zh3MfnfNPpyLZnYg7ah4kbT9JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.21.tgz",
+      "integrity": "sha512-YyBTAFM/QPqt1PscD8hDmCLnqPGKmUZpqeE25HXY8OLjl2MUs8+O4KjwPZZ+OGxpdTbwuWFyMoxjcLy80JODvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.21.tgz",
+      "integrity": "sha512-DQD+ooJmwpNsh4acrftdkuwl5LNxxg8U4+C/RJNDd7m5FP9Wo4c0URi5U0a9Vk/6sQNh9aSGcYChDpqCDWEcBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.21.tgz",
+      "integrity": "sha512-y1L49+snt1a1gLTYPY641slqy55QotPdtRK9Y6jMi4JBQyZwxC8swWYlQWb+MyILwxA614fi62SCNZNznB3XSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.11.21",
       "cpu": [
@@ -630,6 +695,54 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.21.tgz",
+      "integrity": "sha512-DJJe9k6gXR/15ZZVLv1SKhXkFst8lYCeZRNHH99SlBodvu4slhh/MKQ6YCixINRhCwliHrpXPym8/5fOq8b7Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.21.tgz",
+      "integrity": "sha512-TqEXuy6wedId7bMwLIr9byds+mKsaXVHctTN88R1UIBPwJA92Pdk0uxDgip0pEFzHB/ugU27g6d8cwUH3h2eIw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.21.tgz",
+      "integrity": "sha512-BT9BNNbMxdpUM1PPAkYtviaV0A8QcXttjs2MDtOeSqqvSJaPtyM+Fof2/+xSwQDmDEFzbGCcn75M5+xy3lGqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -820,14 +933,16 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
-        "@types/serve-static": "*"
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
@@ -840,13 +955,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/flatbuffers": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.3.tgz",
-      "integrity": "sha512-kwJQsAROanCiMXSLjcTLmYVBIJ9Qyuqs92SaDIcj2EII2KnDgZbiU7it1Z/JfZd1gmxw/lAahMysQ6ZM+j3Ryw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -862,18 +970,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/nanomsg": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@types/nanomsg/-/nanomsg-4.2.3.tgz",
-      "integrity": "sha512-sOI2JzJtl48oMvIlCJ8p0OHJZ+IUZlZIvOljzhPiwm/pcWPbMEbK/T05t1MRpT5TxGGq7NyQYPYmlitdwGs6xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "22.13.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
+      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -924,19 +1024,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/type-utils": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.1"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -946,21 +1047,33 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -970,12 +1083,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -992,34 +1107,21 @@
     },
     "node_modules/@typescript-eslint/parser/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.28.0",
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.28.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1029,12 +1131,98 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1051,11 +1239,15 @@
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1067,18 +1259,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/visitor-keys": "8.28.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.1"
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1088,19 +1283,36 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.4.0",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1116,14 +1328,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1131,18 +1345,22 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.28.0",
-        "@typescript-eslint/types": "8.28.0",
-        "@typescript-eslint/typescript-estree": "8.28.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1152,17 +1370,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.28.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1170,6 +1390,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -1336,13 +1569,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-to-esprima": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-2.0.8.tgz",
-      "integrity": "sha512-b/FfVP95Kf/icFRVMh8hQho/9XcwHBMmsmFgRZ1qNM7NsnekwuC+a0VUAXWmB5JFo99IeoCpHqVe0i0C2YqzxA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1401,14 +1627,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "license": "MIT",
@@ -1422,27 +1640,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansidiff": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansidiff/-/ansidiff-1.0.0.tgz",
-      "integrity": "sha512-dCVfMJDZJkSA0O85CN+lkhcjFC1cekKWWEr2tZgNBnIgMKymE5iBw8jhVPvPZfO6v+kooJ6l4yWJs9WCi/pM9g==",
-      "dev": true,
-      "engines": [
-        "node >=0.4.0"
-      ],
-      "dependencies": {
-        "diff": "1.0"
-      }
-    },
-    "node_modules/ansidiff/node_modules/diff": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha512-1zEb73vemXFpUmfh3fsta4YHz3lwebxXvaWmPbFv9apujQBWDnkrPDLXLQs1gZo4RCWMDsT89r0Pf/z8/02TGA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/arg": {
       "version": "5.0.2",
       "license": "MIT"
@@ -1453,207 +1650,9 @@
       "license": "Python-2.0",
       "peer": true
     },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/babel-traverse/node_modules/globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "node_modules/babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "babylon": "bin/babylon.js"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1719,20 +1718,10 @@
       "version": "1.1.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/brorand": {
@@ -1810,46 +1799,11 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffer-equals-polyfill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-equals-polyfill/-/buffer-equals-polyfill-1.0.0.tgz",
-      "integrity": "sha512-x1VPKw5VJE4cG5g0GVzVMxUHB7maZCOCY16bWAiROIXO4EAZrACGPvlHA+71gWiG6mPlKSkW98XKjTf8ILZ4aw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-compare": "^0.0.1"
-      }
-    },
-    "node_modules/buffer-equals-polyfill/node_modules/buffer-compare": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-0.0.1.tgz",
-      "integrity": "sha512-y8uF98PECs0iUFtn0qjR/MmKSNHXuyJt4jVZl+iVT5tVpv3E9isWmtp2yXZjoyuwB+b77s+DFdqRZHpulde6XQ==",
-      "dev": true
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -1862,21 +1816,33 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "dev": true,
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
       },
-      "engines": {
-        "node": ">= 0.4"
+      "peerDependencies": {
+        "magicast": "^0.3.5"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1911,30 +1877,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1977,18 +1919,37 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/charm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==",
-      "dev": true,
-      "license": "MIT/X11"
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/cliui": {
@@ -2041,7 +2002,25 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2071,20 +2050,6 @@
       "version": "1.0.6",
       "license": "MIT"
     },
-    "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -2097,67 +2062,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-find-index": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "license": "MIT",
@@ -2165,98 +2069,28 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/deep-equal": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.5",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.2",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-equal/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/defined": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2264,6 +2098,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -2273,59 +2114,10 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/difflet": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
-      "integrity": "sha512-ruldDDRmY1t678UOAJBng6sL77f62SqjHj0498YC0EJhxIe2yKkqJn2qEchwG3eU/dqJ/RxPZkAnYjePS4pDCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "charm": "0.1.x",
-        "deep-is": "0.1.x",
-        "traverse": "0.6.x"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/disparity": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/disparity/-/disparity-3.2.0.tgz",
-      "integrity": "sha512-8cl9ouncFYE7OQsYwJNiy2e15S0xN80X1Jj/N/YkoiM+VGWSyg1YzPToecKyYx2DQiJapt5IC8yi43GW23TUHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.2.1",
-        "diff": "^4.0.2"
-      },
-      "bin": {
-        "disparity": "bin/disparity"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/docopt": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/dotenv": {
-      "version": "16.5.0",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2336,6 +2128,8 @@
     },
     "node_modules/dotenv-cli": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-8.0.0.tgz",
+      "integrity": "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -2354,19 +2148,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dotignore": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
-      "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      },
-      "bin": {
-        "ignored": "bin/ignored"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "license": "MIT",
@@ -2378,13 +2159,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -2398,6 +2172,17 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.139",
@@ -2419,9 +2204,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/elliptic/node_modules/inherits": {
@@ -2433,6 +2218,16 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2452,83 +2247,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
@@ -2543,34 +2261,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-module-lexer": {
       "version": "1.6.0",
       "license": "MIT"
@@ -2584,107 +2274,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.25.1",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.1",
-        "@esbuild/android-arm": "0.25.1",
-        "@esbuild/android-arm64": "0.25.1",
-        "@esbuild/android-x64": "0.25.1",
-        "@esbuild/darwin-arm64": "0.25.1",
-        "@esbuild/darwin-x64": "0.25.1",
-        "@esbuild/freebsd-arm64": "0.25.1",
-        "@esbuild/freebsd-x64": "0.25.1",
-        "@esbuild/linux-arm": "0.25.1",
-        "@esbuild/linux-arm64": "0.25.1",
-        "@esbuild/linux-ia32": "0.25.1",
-        "@esbuild/linux-loong64": "0.25.1",
-        "@esbuild/linux-mips64el": "0.25.1",
-        "@esbuild/linux-ppc64": "0.25.1",
-        "@esbuild/linux-riscv64": "0.25.1",
-        "@esbuild/linux-s390x": "0.25.1",
-        "@esbuild/linux-x64": "0.25.1",
-        "@esbuild/netbsd-arm64": "0.25.1",
-        "@esbuild/netbsd-x64": "0.25.1",
-        "@esbuild/openbsd-arm64": "0.25.1",
-        "@esbuild/openbsd-x64": "0.25.1",
-        "@esbuild/sunos-x64": "0.25.1",
-        "@esbuild/win32-arm64": "0.25.1",
-        "@esbuild/win32-ia32": "0.25.1",
-        "@esbuild/win32-x64": "0.25.1"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
-      }
-    },
-    "node_modules/esbuild-register/node_modules/debug": {
-      "version": "4.4.0",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/esbuild-register/node_modules/ms": {
-      "version": "2.1.3",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2708,80 +2297,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/esformatter": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.11.3.tgz",
-      "integrity": "sha512-7nf4RjxjuQ1JtRTajmYdso3MWax3CGk7jOwHeM0l23V7u22wHvpkzu/ByJVwhZRxmXAjLaojJlbdOZVa5xvd2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-to-esprima": "^2.0.6",
-        "babel-traverse": "^6.4.5",
-        "debug": "^4.1.1",
-        "disparity": "^3.0.0",
-        "esformatter-parser": "^1.0.0",
-        "glob": "^7.1.6",
-        "minimatch": "^3.0.2",
-        "minimist": "^1.2.5",
-        "mout": "^1.2.2",
-        "npm-run": "^5.0.1",
-        "resolve": "^1.15.1",
-        "rocambole": ">=0.7 <2.0",
-        "rocambole-indent": "^2.0.4",
-        "rocambole-linebreak": "^1.0.2",
-        "rocambole-node": "~1.0",
-        "rocambole-token": "^1.1.2",
-        "rocambole-whitespace": "^1.0.0",
-        "stdin": "*",
-        "strip-json-comments": "^3.0.1",
-        "supports-color": "^7.1.0",
-        "user-home": "^2.0.0"
-      },
-      "bin": {
-        "esformatter": "bin/esformatter"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/esformatter-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esformatter-parser/-/esformatter-parser-1.0.0.tgz",
-      "integrity": "sha512-D3JVvdPvcoLBfT2dmojEZninyms+9sa2nP9H0OhAsjW2HrHurfZWuNNLPEp4V9wCnnK0QAAks7ZMaG+GBLHd5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-to-esprima": "^2.0.8",
-        "babel-traverse": "^6.9.0",
-        "babylon": "^6.8.0",
-        "rocambole": "^0.7.0"
-      }
-    },
-    "node_modules/esformatter/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/esformatter/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint": {
       "version": "9.23.0",
@@ -2865,6 +2380,7 @@
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2912,18 +2428,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "2.7.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "dev": true,
@@ -2957,6 +2461,7 @@
       "version": "2.0.3",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2983,37 +2488,39 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -3026,35 +2533,72 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3082,14 +2626,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "dev": true,
@@ -3107,17 +2643,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/finalhandler": {
       "version": "1.3.1",
@@ -3165,7 +2690,9 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "25.2.10",
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
@@ -3173,20 +2700,6 @@
       "dev": true,
       "license": "ISC",
       "peer": true
-    },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -3206,40 +2719,8 @@
       "version": "1.0.6",
       "license": "Unlicense"
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3274,16 +2755,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "license": "MIT",
@@ -3295,49 +2766,22 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "dev": true,
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
       },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob-parent": {
@@ -3403,21 +2847,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -3432,71 +2861,6 @@
       "version": "4.2.11",
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-dynamic-import": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/has-dynamic-import/-/has-dynamic-import-2.1.1.tgz",
-      "integrity": "sha512-DuTCn6K/RW8S27npDMumGKsjG6HE7MxzedZka5tJP+9dqfxks+UMqKBmeCijHtIhsBEZPlbMg0qMHi2nKYVtKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "license": "MIT",
@@ -3504,48 +2868,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3586,13 +2911,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/hirestime": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/hirestime/-/hirestime-0.2.4.tgz",
-      "integrity": "sha512-HURILAF7R6lDl0N4RLHCDdWhoTV4rLj5hauDatHOt+hFx5zK+kNtoLP9byNXBfV/MWIXRq63lAv2H52LZvQUYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3603,11 +2921,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/http_ece": {
       "version": "1.2.0",
@@ -3713,6 +3026,7 @@
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -3742,28 +3056,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "repeating": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.1",
       "license": "ISC"
@@ -3776,27 +3068,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "dev": true,
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
       "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -3804,102 +3082,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -3916,70 +3098,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3989,217 +3114,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-utf8": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4230,12 +3155,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4322,21 +3250,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/load-json-file": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "license": "MIT",
@@ -4359,11 +3272,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "license": "MIT"
@@ -4378,45 +3286,26 @@
       "version": "5.3.2",
       "license": "Apache-2.0"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lotus-nng-client": {
-      "resolved": "submodules/lotus-nng-client",
-      "link": true
-    },
-    "node_modules/loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==",
-      "dev": true,
+      "version": "0.1.0",
+      "resolved": "file:submodules/lotus-nng-client",
       "license": "MIT",
       "dependencies": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "dotenv": "17.2.2",
+        "flatbuffers": "25.9.23",
+        "nanomsg": "file:submodules/nanomsg"
       }
     },
-    "node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/lotus-nng-client/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4450,28 +3339,6 @@
         "url": "https://github.com/sponsors/streamich"
       }
     },
-    "node_modules/meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "license": "MIT",
@@ -4483,31 +3350,11 @@
       "version": "2.0.0",
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -4551,6 +3398,7 @@
       "version": "3.1.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4565,13 +3413,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mout": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
-      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
@@ -4583,8 +3424,14 @@
       "license": "MIT"
     },
     "node_modules/nanomsg": {
-      "resolved": "submodules/lotus-nng-client/submodules/nanomsg",
-      "link": true
+      "version": "4.2.4",
+      "resolved": "file:submodules/lotus-nng-client/submodules/nanomsg",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.18.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4602,117 +3449,41 @@
       "version": "2.6.2",
       "license": "MIT"
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "license": "MIT"
     },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/npm-path": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
-      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
-      "dev": true,
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "which": "^1.2.10"
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
       },
       "bin": {
-        "npm-path": "bin/npm-path"
+        "nypm": "dist/cli.mjs"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=18"
       }
     },
-    "node_modules/npm-path/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/npm-run": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-5.0.1.tgz",
-      "integrity": "sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0",
-        "npm-path": "^2.0.4",
-        "npm-which": "^3.0.1",
-        "serializerr": "^1.0.3"
-      },
-      "bin": {
-        "npm-run": "bin/npm-run.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/npm-which": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
-      "integrity": "sha512-CM8vMpeFQ7MAPin0U3wzDhSGV0hMHNwHU0wjo402IVizPDrs45jSfSuoC+wThevY88LQti8VvaAnqYAeVy3I1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.9.0",
-        "npm-path": "^2.0.2",
-        "which": "^1.2.10"
-      },
-      "bin": {
-        "npm-which": "bin/npm-which.js"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/npm-which/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -4724,49 +3495,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -4776,14 +3510,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -4801,32 +3527,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -4871,27 +3571,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-json": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/parse-ms": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
-      "integrity": "sha512-LpH1Cf5EYuVjkBvCDBYvkUPh+iv2bk3FHflxHkpCYT0/FZ1d3N3uJaLiHr4yGuMcFUhv6eAivitTvWZI4B/chg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -4906,14 +3585,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -4932,77 +3603,34 @@
       "version": "0.1.12",
       "license": "MIT"
     },
-    "node_modules/path-type": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
     },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
+    "node_modules/pkg-types": {
       "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "pinkie": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plur": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
-      "integrity": "sha512-qSnKBSZeDY8ApxwhfVIwKwF36KVJqb1/9nzYYq3j3vdwocULCXT8f8fQGkiw1Nk9BGfxiDagEe/pwakA+bOBqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/prelude-ls": {
@@ -5015,7 +3643,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5028,43 +3658,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/pretty-ms": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-1.4.0.tgz",
-      "integrity": "sha512-7YtDT0o1Veo9o4ytk/qyY0tVyx4zWkXnUtjPCfMlEeSCQgqeyyU8g3lzVtC/CyvGZzTk/lvzfLOt4pzxjtdu5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-stdin": "^4.0.1",
-        "is-finite": "^1.0.1",
-        "meow": "^3.3.0",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
-      },
-      "bin": {
-        "pretty-ms": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/prisma": {
-      "version": "6.5.0",
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.5.0",
-        "@prisma/engines": "6.5.0"
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
         "node": ">=18.18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.3"
       },
       "peerDependencies": {
         "typescript": ">=5.1.0"
@@ -5073,21 +3682,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/prisma/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/proto3-json-serializer": {
@@ -5122,13 +3716,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/protochain": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
-      "integrity": "sha512-4hDwFSX50C4NE6f/6zg8EPr/WLPTkFPUtG0ulWZu6bwzV2hmb50fpdQLr0HiKBAUehapaFpItzWoCLjraLJhUA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
@@ -5149,6 +3736,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.13.0",
       "license": "BSD-3-Clause",
@@ -5161,25 +3765,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -5208,147 +3793,29 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "1.1.0",
-      "dev": true,
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
       }
     },
-    "node_modules/read-pkg-up": {
-      "version": "1.0.1",
-      "dev": true,
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "node": ">= 14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-finite": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/require-directory": {
@@ -5393,153 +3860,12 @@
         "node": ">=4"
       }
     },
-    "node_modules/resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rocambole": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
-      "integrity": "sha512-mYIJcS15kZkq5F2uFaqEEkYHvSAI368+jhx+oHMxsVMV0iycYK/rwJ3wcvE37AEYNlToDTICJZo/ZiuuAl6vkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esprima": "^2.1"
-      }
-    },
-    "node_modules/rocambole-indent": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
-      "integrity": "sha512-/N3lT+gjpWkHjMkFEBCQnLs1jZK4/QcGk6PFpwUO4Syk+wjM1N3jRY5p0N1MbH5A7oTiCxOAtDARbXdRtUGk9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "mout": "^0.11.0",
-        "rocambole-token": "^1.2.1"
-      }
-    },
-    "node_modules/rocambole-indent/node_modules/mout": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
-      "integrity": "sha512-pK9VNiLE3QgGBrC/3ICAscwOLU7oTNeK2l32uqNAioBYtB2tQAfSsGDNChUlk7CP23126mc5lUt6+na9FlN8JA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rocambole-linebreak": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.2.tgz",
-      "integrity": "sha512-KzAdY34ux/QInwt1+xDiSE5GWgl/+QmGQMXuR46MMeV+sChORNBMBEbwjCICorBHxFnk4yHwGXV36Tlr195TSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "rocambole-token": "^1.2.1",
-        "semver": "^4.3.1"
-      }
-    },
-    "node_modules/rocambole-linebreak/node_modules/semver": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/rocambole-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-node/-/rocambole-node-1.0.0.tgz",
-      "integrity": "sha512-Wc3EEy6CDLbEiVdJNZTaE7+Gpchs+hLsrdnfvBPqF0RKe1OGqiymIt5xooU9vUJFa8p1/rmAU8M2BjV4zpSfHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rocambole-token": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rocambole-token/-/rocambole-token-1.2.1.tgz",
-      "integrity": "sha512-VMNZfT9x9SPiMPZxgaLbp28oipT01BwP7OxpSVj8E9+VhWXftbtfvUZfbF/R1oNkGvD8qUr4vTsJlOuYYVfbxg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rocambole-whitespace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
-      "integrity": "sha512-lDlVVCfzaUKHaa0z1a5CWZCy1mKGah+KLbdJqjN0KovBy5QKQxZgChGWLbyAUk3H0ByE47unONnxZsV7HDutGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^2.1.3",
-        "repeat-string": "^1.5.0",
-        "rocambole-token": "^1.2.1"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
-    },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-array-concat/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -5558,42 +3884,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-push-apply/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5645,7 +3935,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5695,16 +3987,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/serializerr": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
-      "integrity": "sha512-yXUlHj0fjbndhACj2XWtIH5eJv7b/uadyl7CJA8b9wL5mIKm+g0/sL7rDzEmjC+k5y8ggcaP8i049F4FxA0U9Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "protochain": "^1.0.5"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "license": "MIT",
@@ -5716,49 +3998,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -5846,11 +4085,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "license": "BSD-3-Clause",
@@ -5908,72 +4142,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/stdin": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
-      "integrity": "sha512-2bacd1TXzqOEsqRa+eEWkRdOSznwptrs4gqFcpMq5tOtmJUGPZd10W5Lam6wQ4YQ/+qjQt4e9u35yXCF6mrlfQ==",
-      "dev": true
-    },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6004,101 +4178,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-utf8": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-stdin": "^4.0.1"
-      },
-      "bin": {
-        "strip-indent": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6139,326 +4223,11 @@
         "webpack": ">=2"
       }
     },
-    "node_modules/tap-difflet": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/tap-difflet/-/tap-difflet-0.7.2.tgz",
-      "integrity": "sha512-qxJDCFTmKujLMPdJ9T9xgwhGSrP1xIPPU6IFl1VCI6Oee6h6ebwlmydOdmOJ4toxewNrubdn1pDRUcXbpc02+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansidiff": "^1.0.0",
-        "chalk": "^2.3.2",
-        "difflet": "^0.2.6",
-        "docopt": "^0.6.2",
-        "duplexer": "^0.1.1",
-        "hirestime": "^0.2.4",
-        "pretty-ms": "^1.0.0",
-        "tap-parser-yaml": "^0.7.2",
-        "through2": "^0.6.2"
-      },
-      "bin": {
-        "tap-difflet": "bin/tap-difflet"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tap-difflet/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap-difflet/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap-nyan": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tap-nyan/-/tap-nyan-0.0.2.tgz",
-      "integrity": "sha512-sPalKLy9/YOiDW2YJO3mG9mtpehsm/EtG/LDf4nG55h5DvszHrw1Q9dLfg3zj2eXgeSC5CS5kjCmYvU0Ok6QzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "~0.4.0",
-        "duplexer": "~0.1.1",
-        "tap-parser": "~0.4.1",
-        "through2": "~0.2.3"
-      },
-      "bin": {
-        "tap-nyan": "bin/cmd.js",
-        "tnyan": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-nyan/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-nyan/node_modules/chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-nyan/node_modules/object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tap-nyan/node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/tap-nyan/node_modules/through2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "integrity": "sha512-mLa8Bn2mZurjyomGKWRu3Bo2mvoQojFks9NvOK8H+k4kDJNkdEqG522KFZsEFBEl6rKkxTgFbE5+OPcgfvPEHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~1.1.9",
-        "xtend": "~2.1.1"
-      }
-    },
-    "node_modules/tap-nyan/node_modules/xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
-      "dev": true,
-      "dependencies": {
-        "object-keys": "~0.4.0"
-      },
-      "engines": {
-        "node": ">=0.4"
-      }
-    },
-    "node_modules/tap-parser": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-0.4.3.tgz",
-      "integrity": "sha512-jp7SlKlSTgQjRhiiZ99NnkFIhESAhDa2OQfQh5n/XFiAWQm1SyAiYvmhAB128wu2vU1I/O4lBv5Zr+NBKtbZQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "readable-stream": "~1.1.11"
-      }
-    },
-    "node_modules/tap-parser-yaml": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/tap-parser-yaml/-/tap-parser-yaml-0.7.2.tgz",
-      "integrity": "sha512-xKoZmebaGI8pzqxeYzTlDWuNAFMpqtcKsR9/y3YT3j6jjvaa+gG3AEU+yiPcbCTdtaI5/xdJx4VMMxpDuhyclg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.1",
-        "js-yaml": "^3.0.2",
-        "minimist": "^0.2.0",
-        "readable-stream": "~1.1.11"
-      },
-      "bin": {
-        "tap-parser": "bin/cmd.js"
-      }
-    },
-    "node_modules/tap-parser-yaml/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/tap-parser-yaml/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tap-parser-yaml/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/tap-parser-yaml/node_modules/minimist": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
-      "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tape": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-5.4.0.tgz",
-      "integrity": "sha512-8Cq4mql6oZVO7zkMcen+2AZoJyICsHjJqTiWk1kVub6C/EsS4o9zBVWWbvBBLzx10okW3SKCoNN9XfwfTAIR2w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "deep-equal": "^2.0.5",
-        "defined": "^1.0.0",
-        "dotignore": "^0.1.2",
-        "for-each": "^0.3.3",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.2.0",
-        "has": "^1.0.3",
-        "has-dynamic-import": "^2.0.1",
-        "inherits": "^2.0.4",
-        "is-regex": "^1.1.4",
-        "minimist": "^1.2.5",
-        "object-inspect": "^1.12.0",
-        "object-is": "^1.1.5",
-        "object.assign": "^4.1.2",
-        "resolve": "^2.0.0-next.3",
-        "resumer": "^0.0.0",
-        "string.prototype.trim": "^1.2.5",
-        "through": "^2.3.8"
-      },
-      "bin": {
-        "tape": "bin/tape"
-      }
-    },
-    "node_modules/tape/node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/tape/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/terser": {
@@ -6519,54 +4288,62 @@
         "tslib": "^2"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
-      "dev": true,
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-number": "^7.0.0"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/toidentifier": {
@@ -6574,24 +4351,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/traverse": {
-      "version": "0.6.11",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.11.tgz",
-      "integrity": "sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "gopd": "^1.2.0",
-        "typedarray.prototype.slice": "^1.0.5",
-        "which-typed-array": "^1.1.18"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tree-dump": {
@@ -6608,18 +4367,10 @@
         "tslib": "2"
       }
     },
-    "node_modules/trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6631,6 +4382,8 @@
     },
     "node_modules/ts-patch": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-3.3.0.tgz",
+      "integrity": "sha512-zAOzDnd5qsfEnjd9IGy1IRuvA7ygyyxxdxesbhMdutt8AHFjD8Vw8hU2rMF89HX1BKRWFYqKHrO8Q6lw0NeUZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6692,101 +4445,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typedarray.prototype.slice": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz",
-      "integrity": "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "math-intrinsics": "^1.1.0",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.8.2",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6798,13 +4460,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.28.0",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.28.0",
-        "@typescript-eslint/parser": "8.28.0",
-        "@typescript-eslint/utils": "8.28.0"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6814,12 +4479,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/typescript-transform-paths": {
-      "version": "3.5.5",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.6.tgz",
+      "integrity": "sha512-3eQTG6Ogt+pgPEh45uX2s9OwcfAVjWnyNO+osjYcOqYaWDVMIFUkqW8e0O1cOaVwdMqQFQf6alDT+76xmeS2Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6851,25 +4518,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
     "node_modules/unionfs": {
@@ -6922,33 +4574,11 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-homedir": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -7082,92 +4712,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -7209,15 +4753,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/xpi-ts": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/xpi-ts/-/xpi-ts-0.2.21.tgz",
-      "integrity": "sha512-wcR0RgbUU9anILAzjm9CIr92RJ5+rFo1mmTpArVJnBJ+GIhao+c4ZUd/u+VDnJpUM/Hgi6TdyvxTuyMDrY9lnQ==",
+      "version": "0.3.1",
+      "resolved": "file:../xpi-ts",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.7.2",
@@ -7235,14 +4773,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
       "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
       "license": "MIT"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -7330,407 +4860,6 @@
     "submodules/lotus-lib/submodules/nanomsg": {
       "version": "4.2.4",
       "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.18.0"
-      },
-      "devDependencies": {
-        "buffer-alloc": "1.2.0",
-        "buffer-equals-polyfill": "1.0.0",
-        "buffer-from": "1.1.2",
-        "esformatter": "0.11.3",
-        "tap-difflet": "0.7.2",
-        "tap-nyan": "0.0.2",
-        "tape": "5.4.0"
-      }
-    },
-    "submodules/lotus-nng-client": {
-      "version": "0.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "17.2.2",
-        "flatbuffers": "25.2.10",
-        "nanomsg": "file:submodules/nanomsg"
-      },
-      "devDependencies": {
-        "@types/flatbuffers": "1.10.3",
-        "@types/nanomsg": "4.2.3",
-        "@types/node": "24.3.1",
-        "prettier": "3.6.2",
-        "typescript": "5.9.2",
-        "typescript-eslint": "8.43.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.10.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
-      "integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/type-utils": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.43.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/parser": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
-      "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/project-service": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
-      "integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.43.0",
-        "@typescript-eslint/types": "^8.43.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
-      "integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
-      "integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
-      "integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/types": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
-      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
-      "integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.43.0",
-        "@typescript-eslint/tsconfig-utils": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/visitor-keys": "8.43.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/utils": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
-      "integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.43.0",
-        "@typescript-eslint/types": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
-      "integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.43.0",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/dotenv": {
-      "version": "17.2.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "submodules/lotus-nng-client/node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/typescript-eslint": {
-      "version": "8.43.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.43.0.tgz",
-      "integrity": "sha512-FyRGJKUGvcFekRRcBKFBlAhnp4Ng8rhe8tuvvkR9OiU0gfd4vyvTRQHEckO6VDlH57jbeUQem2IpqPq9kLJH+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.43.0",
-        "@typescript-eslint/parser": "8.43.0",
-        "@typescript-eslint/typescript-estree": "8.43.0",
-        "@typescript-eslint/utils": "8.43.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "submodules/lotus-nng-client/node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "submodules/lotus-nng-client/submodules/nanomsg": {
-      "version": "4.2.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,30 +29,31 @@
   },
   "homepage": "https://github.com/LotusiaStewardship/rank-backend-ts#readme",
   "devDependencies": {
-    "@types/express": "4.17.21",
+    "@types/express": "4.17.25",
     "@types/node": "22.13.14",
     "@types/validator": "13.12.3",
     "@types/web-push": "3.6.4",
-    "prettier": "3.5.3",
-    "prisma": "6.5.0",
+    "prettier": "3.8.3",
+    "prisma": "6.19.3",
     "ts-patch": "3.3.0",
-    "typescript": "5.8.2",
-    "typescript-eslint": "8.28.0",
-    "typescript-transform-paths": "3.5.5"
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.58.2",
+    "typescript-transform-paths": "3.5.6"
   },
   "dependencies": {
-    "@prisma/client": "6.5.0",
+    "@prisma/client": "6.19.3",
     "@temporalio/activity": "1.11.7",
     "@temporalio/client": "1.11.7",
     "@temporalio/worker": "1.11.7",
     "@temporalio/workflow": "1.11.7",
-    "dotenv": "16.5.0",
+    "dotenv": "16.6.1",
     "dotenv-cli": "8.0.0",
-    "express": "4.21.2",
-    "flatbuffers": "25.2.10",
+    "express": "4.22.1",
+    "express-rate-limit": "8.3.2",
+    "flatbuffers": "25.9.23",
     "lotus-nng-client": "file:submodules/lotus-nng-client",
     "nanomsg": "file:submodules/lotus-nng-client/submodules/nanomsg",
     "web-push": "3.6.7",
-    "xpi-ts": "0.2.21"
+    "xpi-ts": "0.3.1"
   }
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -275,17 +275,34 @@ model FaucetClaim {
 // tier, streak, and lifetime statistics. Updated daily during payout
 // and on-demand via the engagement API endpoint.
 model WalletEngagement {
+  // Primary key: the P2PKH script payload (wallet address)
   scriptPayload     String    @id
+  // Current engagement tier (0-4, determines reward multiplier)
   tier              Int       @default(0)
+  // Composite engagement points score (0-100 scale)
   engagementPoints  Float     @default(0)
+  // JSON breakdown of EP components (votes, referrals, comments, streaks)
   epBreakdown       Json      @default("{}")
+  // Total number of votes cast by this wallet
   lifetimeVotes     Int       @default(0)
+  // Total number of successful referrals made by this wallet
   lifetimeReferrals Int       @default(0)
+  // Total number of comments posted by this wallet
   lifetimeComments  Int       @default(0)
+  // Current consecutive days with voting activity
   currentStreak     Int       @default(0)
+  // Longest streak ever achieved by this wallet
   longestStreak     Int       @default(0)
+  // Date of the most recent vote (for streak calculation)
   lastVoteDate      DateTime?
+  // Running total of sats burned across all RANK transactions (for burn EP calculation)
+  totalBurnedSats   BigInt    @default(0)
+  // Date of the earliest vote (for account age EP calculation)
+  firstVoteDate     DateTime?
+  // Total rewards earned by this wallet (in satoshis)
   lifetimeRewards   BigInt    @default(0)
+  // Timestamp of last engagement update
   updatedAt         DateTime  @updatedAt
+  // Timestamp when this engagement record was created
   createdAt         DateTime  @default(now())
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,14 +11,11 @@
     ],
     "outDir": "./.output",
     "paths": {
-      "lotus-lib": [
-        "./submodules/lotus-lib"
-      ],
       "lotus-nng-client": [
         "./submodules/lotus-nng-client"
       ],
-      "lotus-nng-client/lib/nng-interface": [
-        "./submodules/lotus-nng-client/lib/nng-interface"
+      "lotus-nng-client/*": [
+        "./submodules/lotus-nng-client/*"
       ]
     },
     "declaration": false,

--- a/util/auth.ts
+++ b/util/auth.ts
@@ -1,0 +1,66 @@
+import { Block } from 'lotus-nng-client'
+import { AuthorizationPayload } from '../lib/api/authCache'
+import { isBase64, Util } from './functions'
+import { HTTP } from './constants'
+import type { Response } from 'express'
+
+/**
+ * Sends an HTTP "401 Unauthorized" response with a `WWW-Authenticate` header
+ * @param res Express Response object to send the response
+ * @param checkpoint The latest indexed block to use for the challenge
+ */
+export function sendAuthChallenge(res: Response, checkpoint: Block) {
+  const { hash, height } = checkpoint
+  res
+    .contentType('text/plain')
+    .status(HTTP.UNAUTHORIZED)
+    .header(
+      'WWW-Authenticate',
+      `BlockDataSig blockhash=${hash} blockheight=${height}`,
+    )
+    .send(`${HTTP.UNAUTHORIZED} Unauthorized`)
+}
+
+/**
+ * Extracts the script payload from the authorization header
+ * @param authorizationHeader - The authorization header string to process, expected in base64 format
+ * @returns The script payload or null if invalid
+ */
+export function extractScriptPayload(header: string): string | null {
+  const result = processAuthorizationHeader(header)
+  if (!result) {
+    return null
+  }
+  return result.authData.scriptPayload
+}
+
+/**
+ * Processes an authorization header string to extract authorization data, data string and signature
+ * @param {string} header - The authorization header string to process, expected in base64 format
+ * @returns Tuple containing:
+ *   - AuthorizationPayload object or null if invalid
+ *   - Raw authorization data string or null if invalid
+ *   - Signature string or null if invalid
+ */
+export function processAuthorizationHeader(header: string | undefined): {
+  authData: AuthorizationPayload
+  authPayloadStr: string
+  signature: string
+} | null {
+  if (header === undefined) {
+    return null
+  }
+  if (!isBase64(header)) {
+    return null
+  }
+  const [authPayloadStr, signature] = Util.base64.decode(header).split(':::')
+  if (!authPayloadStr || !signature) {
+    return null
+  }
+  const authData = JSON.parse(authPayloadStr ?? '{}') as AuthorizationPayload
+  return {
+    authData,
+    authPayloadStr,
+    signature,
+  }
+}

--- a/util/functions.ts
+++ b/util/functions.ts
@@ -11,6 +11,7 @@ import {
   Message,
   Networks,
   Script,
+  ScriptType,
 } from 'xpi-ts/lib/bitcore'
 import type { Request, Response } from 'express'
 import type { TopicCategory, Topic } from '../lib/push'
@@ -41,7 +42,7 @@ export function* toAsyncIterable<T>(iterable: Iterable<T>) {
  * If invalid, returns false.
  * @returns True if the instance ID is valid, false otherwise
  */
-export async function isValidInstanceId({
+export async function recomputeInstanceId({
   instanceId,
   runtimeId,
   startTime,
@@ -68,7 +69,7 @@ export async function isValidInstanceId({
     )
   } catch (e) {
     log([
-      ['api.error', 'isValidInstanceId'],
+      ['api.error', 'recomputeInstanceId'],
       ['error', (e as Error).message],
     ])
     return false
@@ -263,195 +264,5 @@ export const Util = {
     randomUUID(): string {
       return crypto.randomUUID()
     },
-  },
-}
-
-/**
- * Validator functions for API parameters
- */
-export const Validate = {
-  /**
-   * Validates that the provided `instanceId` is a 64-character hexadecimal string.
-   * If invalid, responds with HTTP 400 and an error message.
-   * @param instanceId - The instance ID to validate
-   * @returns The validated instance ID
-   */
-  instanceId: (instanceId: string | undefined) => {
-    if (instanceId === undefined) {
-      return {
-        error: 'instanceId must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    if (!instanceId.match(/^[a-f0-9]{64}$/)) {
-      return {
-        error: 'instanceId is invalid format',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    // TODO: validate instanceId matches input and meets/exceeds difficulty
-
-    return { instanceId }
-  },
-
-  /**
-   * Validates that the provided `scriptPayload` is a valid script payload.
-   * If invalid, responds with HTTP 400 and an error message.
-   * Accepts both P2PKH/P2SH (20 bytes) and Taproot (33 bytes) scriptPayloads.
-   * @param scriptPayload - The script payload to validate
-   * @returns The validated script payload
-   */
-  scriptPayload: (scriptPayload: string | undefined) => {
-    if (scriptPayload === undefined) {
-      return {
-        error: 'scriptPayload must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    const buffer = BufferUtil.from(scriptPayload, 'hex')
-    if (buffer.byteLength === 20 || buffer.byteLength === 33) {
-      // Valid scriptPayload length, now validate the format
-      try {
-        const script = Script.fromBuffer(buffer)
-        if (script.isValid()) {
-          return {
-            scriptPayload,
-          }
-        }
-      } catch (e) {
-        return {
-          error: 'scriptPayload is invalid',
-          statusCode: HTTP.BAD_REQUEST,
-        }
-      }
-    }
-    return {
-      error: 'scriptPayload is invalid',
-      statusCode: HTTP.BAD_REQUEST,
-    }
-  },
-
-  /**
-   * Validates a message signature
-   * @param scriptPayload - PKH used to generate `Address` for signature validation
-   * @param data - The data payload to verify against the signature
-   * @param signature - The signature of the data payload to validate
-   * @returns The validated signature
-   */
-  signature: ({
-    scriptPayload,
-    data,
-    signature,
-  }: {
-    scriptPayload: string | undefined
-    data: string | undefined
-    signature: string | undefined
-  }) => {
-    if (scriptPayload === undefined) {
-      return {
-        error: 'scriptPayload must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    if (signature === undefined) {
-      return {
-        error: 'signature must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    if (data === undefined) {
-      return {
-        error: 'data must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    // convert scriptPayload to Address
-    const address = Address.fromPublicKeyHash(
-      BufferUtil.from(scriptPayload, 'hex'),
-      Networks.livenet,
-    )
-    // verify message signature
-    const message = new Message(data)
-    if (!message.verify(address, signature)) {
-      return {
-        error: 'message signature is invalid',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    return { signature }
-  },
-
-  /**
-   * Validates a search type
-   * @param searchType - The search type to validate
-   * @returns The validated search type
-   */
-  searchType: (searchType: 'profile' | 'post' | undefined) => {
-    if (searchType === undefined) {
-      return {
-        error: 'search type must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    if (!['profile', 'post'].includes(searchType)) {
-      return {
-        error: 'invalid search type specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    return { searchType }
-  },
-
-  /**
-   * Validates that the provided referral code is a valid hex string of the expected length
-   * @param code - The referral code to validate
-   * @returns The validated referral code or an error
-   */
-  referralCode: (code: string | undefined) => {
-    if (code === undefined || code.length === 0) {
-      return {
-        error: 'referral code must be specified',
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    const regex = new RegExp(`^[a-f0-9]{${REFERRAL_CODE_LENGTH}}$`)
-    if (!regex.test(code)) {
-      return {
-        error: `referral code must be a ${REFERRAL_CODE_LENGTH}-character hex string`,
-        statusCode: HTTP.BAD_REQUEST,
-      }
-    }
-    return { code }
-  },
-
-  /**
-   * Validates the admin secret header against the configured ADMIN_SECRET
-   * @param header - The admin secret header value
-   * @param configuredSecret - The configured admin secret from environment
-   * @returns Success or error
-   */
-  adminSecret: (
-    header: string | undefined,
-    configuredSecret: string | undefined,
-  ) => {
-    if (!configuredSecret) {
-      return {
-        error: 'admin endpoint not configured',
-        statusCode: HTTP.NOT_FOUND,
-      }
-    }
-    if (header === undefined || header.length === 0) {
-      return {
-        error: 'admin secret must be specified',
-        statusCode: HTTP.UNAUTHORIZED,
-      }
-    }
-    if (header !== configuredSecret) {
-      return {
-        error: 'invalid admin secret',
-        statusCode: HTTP.FORBIDDEN,
-      }
-    }
-    return { valid: true }
   },
 }

--- a/util/functions.ts
+++ b/util/functions.ts
@@ -122,6 +122,16 @@ export function sendJSON(res: Response, data: object, statusCode?: number) {
     .json(data)
 }
 /**
+ * Sends a rate limit JSON error response to the client
+ * @param req Express Request object (unused but required for express-rate-limit handler signature)
+ * @param res Express Response object to send the error response
+ */
+export function sendRateLimitExceededJSON(_req: Request, res: Response) {
+  res.contentType('application/json').status(HTTP.FORBIDDEN).json({
+    error: '401 Too many requests, please try again later.',
+  })
+}
+/**
  * Sends an error JSON response and logs the error
  * @param res Express Response object to send the JSON response
  * @param error The error message to send

--- a/util/validators.ts
+++ b/util/validators.ts
@@ -1,0 +1,194 @@
+import {
+  Address,
+  BufferUtil,
+  Message,
+  Networks,
+  Script,
+} from 'xpi-ts/lib/bitcore'
+import { HTTP, REFERRAL_CODE_LENGTH } from './constants'
+import type { ScriptType } from 'xpi-ts/lib/bitcore'
+
+/**
+ * Validates that the provided `instanceId` is a 64-character hexadecimal string.
+ * If invalid, responds with HTTP 400 and an error message.
+ * @param instanceId - The instance ID to validate
+ * @returns The validated instance ID
+ */
+export function validateInstanceId(instanceId: string | undefined) {
+  if (instanceId === undefined) {
+    return {
+      error: 'instanceId must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  if (!instanceId.match(/^[a-f0-9]{64}$/)) {
+    return {
+      error: 'instanceId is invalid format',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  // TODO: validate instanceId matches input and meets/exceeds difficulty
+
+  return { instanceId }
+}
+
+/**
+ * Validates that the provided `scriptPayload` is a valid script payload.
+ * If invalid, responds with HTTP 400 and an error message.
+ * Accepts both P2PKH/P2SH (20 bytes) and Taproot (33 bytes) scriptPayloads.
+ * @param scriptPayload - The script payload to validate
+ * @returns The validated script payload
+ */
+export function validateScriptPayload(scriptPayload: string | undefined) {
+  if (scriptPayload === undefined) {
+    return {
+      error: 'scriptPayload must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  const buffer = BufferUtil.from(scriptPayload, 'hex')
+  let scriptType: ScriptType
+  if (buffer.byteLength === 20) {
+    scriptType = 'p2pkh'
+  } else if (buffer.byteLength === 33) {
+    scriptType = 'p2tr-commitment'
+  } else {
+    return {
+      error: 'scriptPayload is unsupported type',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+
+  // Valid scriptPayload length, now validate the format
+  try {
+    const script = Script.fromPayload(scriptType, buffer)
+    if (script.isValid()) {
+      return {
+        scriptPayload,
+      }
+    }
+  } catch (e) {
+    // no special handling here is necessary
+  }
+
+  return {
+    error: 'scriptPayload is invalid',
+    statusCode: HTTP.BAD_REQUEST,
+  }
+}
+
+/**
+ * Validates a message signature
+ * @param scriptPayload - PKH used to generate `Address` for signature validation
+ * @param data - The data payload to verify against the signature
+ * @param signature - The signature of the data payload to validate
+ * @returns The validated signature
+ */
+export function validateSignature({ scriptPayload, data, signature }) {
+  if (scriptPayload === undefined) {
+    return {
+      error: 'scriptPayload must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  if (signature === undefined) {
+    return {
+      error: 'signature must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  if (data === undefined) {
+    return {
+      error: 'data must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  // convert scriptPayload to Address
+  const address = Address.fromPublicKeyHash(
+    BufferUtil.from(scriptPayload, 'hex'),
+    Networks.livenet,
+  )
+  // verify message signature
+  const message = new Message(data)
+  if (!message.verify(address, signature)) {
+    return {
+      error: 'message signature is invalid',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  return { signature }
+}
+
+/**
+ * Validates a search type
+ * @param searchType - The search type to validate
+ * @returns The validated search type
+ */
+export function validateSearchType(searchType: 'profile' | 'post' | undefined) {
+  if (searchType === undefined) {
+    return {
+      error: 'search type must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  if (!['profile', 'post'].includes(searchType)) {
+    return {
+      error: 'invalid search type specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  return { searchType }
+}
+
+/**
+ * Validates that the provided referral code is a valid hex string of the expected length
+ * @param code - The referral code to validate
+ * @returns The validated referral code or an error
+ */
+export function validateReferralCode(code: string | undefined) {
+  if (code === undefined || code.length === 0) {
+    return {
+      error: 'referral code must be specified',
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  const regex = new RegExp(`^[a-f0-9]{${REFERRAL_CODE_LENGTH}}$`)
+  if (!regex.test(code)) {
+    return {
+      error: `referral code must be a ${REFERRAL_CODE_LENGTH}-character hex string`,
+      statusCode: HTTP.BAD_REQUEST,
+    }
+  }
+  return { code }
+}
+
+/**
+ * Validates the admin secret header against the configured ADMIN_SECRET
+ * @param header - The admin secret header value
+ * @param configuredSecret - The configured admin secret from environment
+ * @returns Success or error
+ */
+export function validateAdminSecret(
+  header: string | undefined,
+  configuredSecret: string | undefined,
+) {
+  if (!configuredSecret) {
+    return {
+      error: 'admin endpoint not configured',
+      statusCode: HTTP.NOT_FOUND,
+    }
+  }
+  if (header === undefined || header.length === 0) {
+    return {
+      error: 'admin secret must be specified',
+      statusCode: HTTP.UNAUTHORIZED,
+    }
+  }
+  if (header !== configuredSecret) {
+    return {
+      error: 'invalid admin secret',
+      statusCode: HTTP.FORBIDDEN,
+    }
+  }
+  return { valid: true }
+}


### PR DESCRIPTION
## Core Changes

- Add RNKE specification (draft) and related docs.
- Indexer: increment WalletEngagement for RANK/RNKC during indexing.
- Database:
  - Implement EP / engagement increment queries and EP (engagement points) bookkeeping.
  - Apply R66 velocity dampening in apiGetFeedPosts to reduce feed spam.
  - Add prisma fields: totalBurnedSats, firstVoteDate.
- API: implement a request rate limiter to protect public endpoints.
- Miscellaneous: tsconfig cleanup (remove deprecated submodule paths), README and jsdoc improvements, small refactors (utilities split), eslint tweak for explicit any casting, TypeScript array/Uint8Array cast fix, update lotus-nng-client submodule and other deps.

## Migration & verification
- Database migration required: run prisma migrate (or equivalent) to add totalBurnedSats and firstVoteDate before deploying.
- Recommended verification: npm run format && npm run lint && npm run build && npm test.
- Restart services that depend on updated submodules (lotus-nng-client) after deployment.

## BREAKING CHANGES
- Adds new DB columns (totalBurnedSats, firstVoteDate) — schema migration required.
- Behavior change: feed ranking now applies R66 velocity dampening; expect different feed ordering for high-frequency activity.
Notes
- Many changes are internal bookkeeping and defensive (rate limiting, dampening). Docs and jsdoc were updated to aid reviewers